### PR TITLE
SETᴰ has VerticalTerminalsᴰ

### DIFF
--- a/Cubical/Categories/Displayed/Fibration/Properties.agda
+++ b/Cubical/Categories/Displayed/Fibration/Properties.agda
@@ -98,6 +98,11 @@ module _ {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ') where
     AllVertical→Vertical/𝟙 : VerticalTerminalsᴰ → Verticalᴰ/𝟙
     AllVertical→Vertical/𝟙 vt = vt (term .vertex)
 
+    -- convenience
+    AllVertical→LiftedTermᴰ : VerticalTerminalsᴰ → LiftedTerminalᴰ Cᴰ term
+    AllVertical→LiftedTermᴰ vt =
+      Verticalᴰ/𝟙→LiftedTermᴰ (AllVertical→Vertical/𝟙 vt)
+
 module _ {C : Category ℓC ℓC'}{D : Category ℓD ℓD'}
   (F : Functor C D)
   (Dᴰ : Categoryᴰ D ℓDᴰ ℓDᴰ')

--- a/Cubical/Categories/Displayed/Instances/Sets/Properties.agda
+++ b/Cubical/Categories/Displayed/Instances/Sets/Properties.agda
@@ -8,14 +8,19 @@ open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Structure
 open import Cubical.Data.Sigma
 open import Cubical.Data.Sigma.Properties
+open import Cubical.Data.Unit
 
 open import Cubical.Categories.Category
 open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Instances.Sets.More
 open import Cubical.Categories.Displayed.Base
 open import Cubical.Categories.Displayed.Functor
 open import Cubical.Categories.Displayed.Fibration.Base
+open import Cubical.Categories.Displayed.Fibration.Properties
 open import Cubical.Categories.Displayed.Instances.Sets.Base
 open import Cubical.Categories.Displayed.Presheaf
+open import Cubical.Categories.Displayed.Limits.Terminal
+
 
 private
   variable
@@ -37,3 +42,16 @@ AllCartesianOversSETᴰ {c = A} {A'} B' f .isCartesian {A''} B'' g gfᴰ =
 isFibrationSet : isFibration (SETᴰ ℓ ℓ')
 isFibrationSet dᴰ = CartesianOver→CartesianLift (SETᴰ _ _)
   (AllCartesianOversSETᴰ _ _)
+
+VerticalTerminalsᴰSETᴰ : VerticalTerminalsᴰ (SETᴰ ℓ ℓ')
+VerticalTerminalsᴰSETᴰ dᴰ .vertexᴰ _ = Unit* , isSetUnit*
+VerticalTerminalsᴰSETᴰ dᴰ .elementᴰ = tt
+VerticalTerminalsᴰSETᴰ dᴰ .universalᴰ .equiv-proof _ = uniqueExists
+  (λ _ _ → tt*)
+  (isPropUnit tt tt)
+  (λ _ p q → isSetUnit tt tt p q)
+  (λ _ _ → funExt λ _ → funExt λ _ → refl)
+
+LiftedTerminalᴰSETᴰ : ∀{ℓ ℓ'} → LiftedTerminalᴰ (SETᴰ ℓ ℓ') terminal'SET
+LiftedTerminalᴰSETᴰ {ℓ} {ℓ'} =
+  AllVertical→LiftedTermᴰ (SETᴰ ℓ ℓ') terminal'SET VerticalTerminalsᴰSETᴰ

--- a/Cubical/Categories/Instances/Sets/More.agda
+++ b/Cubical/Categories/Instances/Sets/More.agda
@@ -9,14 +9,18 @@ open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.Structure
 open import Cubical.Foundations.Univalence
 open import Cubical.Data.Sigma
+open import Cubical.Data.Unit
 
 open import Cubical.Categories.Category
 open import Cubical.Categories.Functor
+open import Cubical.Categories.Limits.Terminal.More
 open import Cubical.Categories.Bifunctor.Redundant
 open import Cubical.Categories.Instances.Sets
 open import Cubical.Categories.Constructions.BinProduct
+open import Cubical.Categories.Presheaf
 
 open import Cubical.Foundations.Isomorphism.More
+
 
 private
   variable
@@ -47,3 +51,13 @@ module _ {A}{B} (f : CatIso (SET ℓ) A B) a where
     ∙ transportRefl _
     ∙ transportRefl _
     ∙ cong (f .fst) (transportRefl _ ∙ transportRefl _ ))
+
+open UniversalElement
+terminal'SET : Terminal' (SET ℓ)
+terminal'SET .vertex = Unit* , isSetUnit*
+terminal'SET .element = tt
+terminal'SET .universal X .equiv-proof y = uniqueExists
+  (λ _ → tt*)
+  (isPropUnit tt tt)
+  (λ _ p' q' → isSetUnit tt tt p' q')
+  (λ _ _ → funExt λ _ → isPropUnit* tt* tt*)


### PR DESCRIPTION
As per zulip messages about https://github.com/maxsnew/cubical-categorical-logic/pull/95

Using the current module locations of Vertical->Lifted and such, which are moving in the above PR.
