### PR TITLE
Simpler functor comprehension

### DIFF
--- a/Cubical/Categories/Constructions/Free/CartesianCategory/Base.agda
+++ b/Cubical/Categories/Constructions/Free/CartesianCategory/Base.agda
@@ -127,17 +127,17 @@ module _ (Q : ×Quiver ℓQ ℓQ') where
           (cong elim-F-hom p) (cong elim-F-hom q)
           i j
         elim-F-hom !ₑ = !tᴰ _
-        -- TODO: Why does this need rectify?
         elim-F-hom (⊤η f i) =
           R.rectify {p' = ⊤η f} (𝟙ηᴰ (elim-F-hom f)) i
         elim-F-hom π₁ = π₁ᴰ
         elim-F-hom π₂ = π₂ᴰ
         elim-F-hom ⟨ f₁ , f₂ ⟩ = elim-F-hom f₁ ,pᴰ elim-F-hom f₂
         elim-F-hom (×β₁ {t = f₁}{t' = f₂} i) =
-          ×β₁ᴰ {f₁ᴰ = elim-F-hom f₁} {f₂ᴰ = elim-F-hom f₂} i
+          R.rectify {p' = ×β₁}
+            ((×β₁ᴰ {f₁ᴰ = elim-F-hom f₁} {f₂ᴰ = elim-F-hom f₂})) i
         elim-F-hom (×β₂ {t = f₁}{t' = f₂} i) =
-          ×β₂ᴰ {f₁ᴰ = elim-F-hom f₁} {f₂ᴰ = elim-F-hom f₂} i
-        -- TODO: Why do we need this rectify too?
+          R.rectify {p' = ×β₂}
+            (×β₂ᴰ {f₁ᴰ = elim-F-hom f₁} {f₂ᴰ = elim-F-hom f₂}) i
         elim-F-hom (×η {t = f} i) =
           R.rectify {p' = ×η {t = f}} (×ηᴰ {fᴰ = elim-F-hom f}) i
 

--- a/Cubical/Categories/Displayed/FunctorComprehension.agda
+++ b/Cubical/Categories/Displayed/FunctorComprehension.agda
@@ -12,6 +12,7 @@ open import Cubical.Foundations.Function
 open import Cubical.Categories.Category
 open import Cubical.Categories.Functor
 open import Cubical.Categories.Profunctor.General
+open import Cubical.Categories.Presheaf.More
 open import Cubical.Categories.FunctorComprehension
 
 import Cubical.Categories.Constructions.TotalCategory as TotalCat

--- a/Cubical/Categories/Displayed/FunctorComprehension.agda
+++ b/Cubical/Categories/Displayed/FunctorComprehension.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --safe --lossy-unification #-}
+{-# OPTIONS --safe  --lossy-unification #-}
 {--
  -- Displayed Functor Comprehension
  -- Construction of a Displayed Functor by defining displayed universal elements
@@ -7,32 +7,17 @@ module Cubical.Categories.Displayed.FunctorComprehension where
 
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.HLevels
-open import Cubical.Foundations.Isomorphism
-open import Cubical.Foundations.Equiv
-open import Cubical.Foundations.Structure
-open import Cubical.Foundations.Univalence
-open import Cubical.Foundations.Function renaming (_∘_ to _∘f_)
+open import Cubical.Foundations.Function
 
-open import Cubical.Categories.Category renaming (isIso to isIsoC)
+open import Cubical.Categories.Category
 open import Cubical.Categories.Functor
-open import Cubical.Categories.Instances.Functors
-open import Cubical.Categories.Instances.Sets
-open import Cubical.Categories.Instances.Sets.More
 open import Cubical.Categories.Profunctor.General
-open import Cubical.Categories.Profunctor.FunctorComprehension
-open import Cubical.Data.Sigma
+open import Cubical.Categories.FunctorComprehension
 
-open import Cubical.Categories.Presheaf.Base
-
-open import Cubical.Categories.Presheaf.Representable
-open import Cubical.Categories.Instances.Functors.More
 import Cubical.Categories.Constructions.TotalCategory as TotalCat
 
 open import Cubical.Categories.Displayed.Base
 open import Cubical.Categories.Displayed.Functor
-open import Cubical.Categories.Displayed.Presheaf
-open import Cubical.Categories.Displayed.Instances.Sets.Base
-open import Cubical.Categories.Displayed.Instances.Functor
 open import Cubical.Categories.Displayed.Profunctor
 import Cubical.Categories.Displayed.Reasoning as Reasoning
 

--- a/Cubical/Categories/Displayed/Limits/BinProduct/Base.agda
+++ b/Cubical/Categories/Displayed/Limits/BinProduct/Base.agda
@@ -96,19 +96,23 @@ module hasAllBinProductᴰNotation
       open isIsoOver
       private
         ,pᴰ-isUniversalᴰ = bpᴰ (d₁ , d₂) .universalᴰ {xᴰ = d}
-      ×β₁ᴰ : ((f₁ᴰ ,pᴰ f₂ᴰ) Cᴰ.⋆ᴰ π₁ᴰ) Cᴰ.≡[ ×β₁ ] f₁ᴰ
-      ×β₁ᴰ i = UniversalElementᴰNotation.βᴰ _ _
-        (bpᴰ (d₁ , d₂)) {pᴰ = (f₁ᴰ , f₂ᴰ)} i .fst
+      opaque
+        unfolding UniversalElementᴰNotation.βᴰ
+        ×β₁ᴰ : ((f₁ᴰ ,pᴰ f₂ᴰ) Cᴰ.⋆ᴰ π₁ᴰ) Cᴰ.≡[ ×β₁ ] f₁ᴰ
+        ×β₁ᴰ = λ i → UniversalElementᴰNotation.βᴰ _ _
+          (bpᴰ (d₁ , d₂)) {pᴰ = (f₁ᴰ , f₂ᴰ)} i .fst
 
-      ×β₂ᴰ : ((f₁ᴰ ,pᴰ f₂ᴰ) Cᴰ.⋆ᴰ π₂ᴰ) Cᴰ.≡[ ×β₂ ] f₂ᴰ
-      ×β₂ᴰ i = UniversalElementᴰNotation.βᴰ _ _
-        (bpᴰ (d₁ , d₂)) {pᴰ = (f₁ᴰ , f₂ᴰ)} i .snd
+        ×β₂ᴰ : ((f₁ᴰ ,pᴰ f₂ᴰ) Cᴰ.⋆ᴰ π₂ᴰ) Cᴰ.≡[ ×β₂ ] f₂ᴰ
+        ×β₂ᴰ = λ i → UniversalElementᴰNotation.βᴰ _ _
+          (bpᴰ (d₁ , d₂)) {pᴰ = (f₁ᴰ , f₂ᴰ)} i .snd
 
     module _ {f : C [ c , c₁ BP.× c₂ ]}
              {fᴰ : Cᴰ.Hom[ f ][ d , d₁ ×ᴰ d₂ ]}
            where
-      ×ηᴰ : fᴰ Cᴰ.≡[ ×η ] ((fᴰ Cᴰ.⋆ᴰ π₁ᴰ) ,pᴰ (fᴰ Cᴰ.⋆ᴰ π₂ᴰ))
-      ×ηᴰ = UniversalElementᴰNotation.ηᴰ _ _ (bpᴰ (d₁ , d₂))
+      opaque
+        unfolding UniversalElementᴰNotation.ηᴰ
+        ×ηᴰ : fᴰ Cᴰ.≡[ ×η ] ((fᴰ Cᴰ.⋆ᴰ π₁ᴰ) ,pᴰ (fᴰ Cᴰ.⋆ᴰ π₂ᴰ))
+        ×ηᴰ = UniversalElementᴰNotation.ηᴰ _ _ (bpᴰ (d₁ , d₂))
 
 module _ {C  : Category ℓC ℓC'}{c : C .ob}{Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'} where
   private

--- a/Cubical/Categories/Displayed/Limits/Terminal.agda
+++ b/Cubical/Categories/Displayed/Limits/Terminal.agda
@@ -69,7 +69,7 @@ module _ {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ') where
     !tᴰ {c} d = introᴰ tt tt
 
     𝟙ηᴰ : ∀ {c} {d : Cᴰ.ob[ c ]} {f} (fᴰ : Cᴰ.Hom[ f ][ d , 𝟙ᴰ ])
-        → fᴰ Cᴰ.≡[ 𝟙η f ] !tᴰ d
+        → fᴰ Cᴰ.≡[ η ] !tᴰ d
     𝟙ηᴰ {c} {d} {f} fᴰ = ηᴰ
 
   module _ (c : C .ob) where

--- a/Cubical/Categories/Displayed/Presheaf.agda
+++ b/Cubical/Categories/Displayed/Presheaf.agda
@@ -36,6 +36,8 @@ open Functorᴰ
 
 -- equivalent to the data of a presheaf Pᴰ over ∫ D and a natural transformation
 -- Pᴰ → P ∘ Fst
+--
+-- IMO the order of D and P here should be swapped to match Functorᴰ
 Presheafᴰ : {C : Category ℓC ℓC'} (D : Categoryᴰ C ℓD ℓD')
           → (P : Presheaf C ℓP) → (ℓPᴰ : Level)
           → Type (ℓ-max (ℓ-max (ℓ-max (ℓ-max (ℓ-max ℓC ℓC') ℓD) ℓD') (ℓ-suc ℓP))
@@ -46,27 +48,61 @@ PRESHEAFᴰ : {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ')
   → ∀ (ℓP ℓPᴰ : Level) → Categoryᴰ (PresheafCategory C ℓP) _ _
 PRESHEAFᴰ Cᴰ ℓP ℓPᴰ = FUNCTORᴰ (Cᴰ ^opᴰ) (SETᴰ ℓP ℓPᴰ)
 
--- TODO: make a PresheafNotation to match
+∫P : {C : Category ℓC ℓC'} {D : Categoryᴰ C ℓD ℓD'}
+     → {P : Presheaf C ℓP} → {ℓPᴰ : Level} → Presheafᴰ D P ℓPᴰ
+     → Presheaf (TotalCat.∫C D) (ℓ-max ℓP ℓPᴰ)
+∫P Pᴰ = ΣF ∘F TotalCat.∫F Pᴰ
+
 module PresheafᴰNotation {C : Category ℓC ℓC'} {Cᴰ : Categoryᴰ C ℓD ℓD'}
          {P : Presheaf C ℓP} (Pᴰ : Presheafᴰ Cᴰ P ℓPᴰ) where
   private
     module C = Category C
     module Cᴰ = Categoryᴰ Cᴰ
+    module P = PresheafNotation P
 
   pob[_] : C .ob → Type ℓP
   pob[ x ] = ⟨ P ⟅ x ⟆ ⟩
 
-  p[_][_] : ∀ {x} → ⟨ P ⟅ x ⟆ ⟩ → Cᴰ.ob[ x ] → Type ℓPᴰ
+  p[_][_] : ∀ {x} → P.p[ x ] → Cᴰ.ob[ x ] → Type ℓPᴰ
   p[ f ][ xᴰ ] = ⟨ Pᴰ .F-obᴰ xᴰ f ⟩
 
-  _≡[_]_ : ∀ {x xᴰ} {f g : ⟨ P ⟅ x ⟆ ⟩} → p[ f ][ xᴰ ] → f ≡ g → p[ g ][ xᴰ ]
+  _⋆ᴰ_ : ∀ {x y xᴰ yᴰ}{f : C [ x , y ]}{g}
+     → Cᴰ [ f ][ xᴰ , yᴰ ] → p[ g ][ yᴰ ]
+     → p[ f P.⋆ g ][ xᴰ ]
+  fᴰ ⋆ᴰ gᴰ = Pᴰ .F-homᴰ fᴰ _ gᴰ
+
+  isSetPsh : ∀ {x} → isSet (P.p[ x ])
+  isSetPsh {x} = (P ⟅ x ⟆) .snd
+
+  _≡[_]_ : ∀ {x xᴰ} {f g : P.p[ x ]} → p[ f ][ xᴰ ] → f ≡ g → p[ g ][ xᴰ ]
     → Type ℓPᴰ
   _≡[_]_ {x} {xᴰ} {f} {g} fᴰ f≡g gᴰ = PathP (λ i → p[ f≡g i ][ xᴰ ]) fᴰ gᴰ
 
-  _⋆ᴰ_ : ∀ {x y xᴰ yᴰ}{f : C [ x , y ]}{g}
-    → Cᴰ [ f ][ xᴰ , yᴰ ] → p[ g ][ yᴰ ]
-    → p[ g ∘ᴾ⟨ C , P ⟩ f ][ xᴰ ]
-  fᴰ ⋆ᴰ gᴰ = Pᴰ .F-homᴰ fᴰ _ gᴰ
+  ≡in : {a : C.ob} {f g : P.p[ a ]}
+        {aᴰ : Cᴰ.ob[ a ]}
+        {fᴰ : p[ f ][ aᴰ ]}
+        {gᴰ : p[ g ][ aᴰ ]}
+        {p : f ≡ g}
+      → (fᴰ ≡[ p ] gᴰ)
+      → (f , fᴰ) ≡ (g , gᴰ)
+  ≡in e = ΣPathP (_ , e)
+
+  ≡out : {a : C.ob} {f g : P.p[ a ]}
+         {aᴰ : Cᴰ.ob[ a ]}
+         {fᴰ : p[ f ][ aᴰ ]}
+         {gᴰ : p[ g ][ aᴰ ]}
+       → (e : (f , fᴰ) ≡ (g , gᴰ))
+       → (fᴰ ≡[ fst (PathPΣ e) ] gᴰ)
+  ≡out e = snd (PathPΣ e)
+
+  rectify : {a : C.ob} {f g : P.p[ a ]} {p p' : f ≡ g}
+      {aᴰ : Cᴰ.ob[ a ]}
+      {fᴰ : p[ f ][ aᴰ ]}
+      {gᴰ : p[ g ][ aᴰ ]}
+    → fᴰ ≡[ p ] gᴰ → fᴰ ≡[ p' ] gᴰ
+  rectify {fᴰ = fᴰ} {gᴰ = gᴰ} = subst (fᴰ ≡[_] gᴰ) (isSetPsh _ _ _ _)
+
+  open PresheafNotation (∫P Pᴰ)
 
 module _ {C : Category ℓC ℓC'} (D : Categoryᴰ C ℓD ℓD')
          {P : Presheaf C ℓP} (Pᴰ : Presheafᴰ D P ℓPᴰ) where
@@ -93,7 +129,7 @@ module _ {C : Category ℓC ℓC'} (D : Categoryᴰ C ℓD ℓD')
     open UniversalElement
     open UniversalElementᴰ
     ∫UE : ∀ {ue : UniversalElement C P} (ueᴰ : UniversalElementᴰ ue)
-      → UniversalElement (TotalCat.∫C D) (ΣF ∘F TotalCat.∫F Pᴰ)
+      → UniversalElement (TotalCat.∫C D) (∫P Pᴰ)
     ∫UE {ue = ue} ueᴰ .vertex = ue .vertex , ueᴰ .vertexᴰ
     ∫UE {ue = ue} ueᴰ .element = ue .element , ueᴰ .elementᴰ
     ∫UE {ue = ue} ueᴰ .universal (v , vᴰ) =
@@ -106,33 +142,40 @@ module _ {C : Category ℓC ℓC'} (D : Categoryᴰ C ℓD ℓD')
     open UniversalElementNotation ue public
     open UniversalElementᴰ ueᴰ public
     private
+      module P = PresheafNotation P
       module ∫ue = UniversalElementNotation (∫UE ueᴰ)
 
     introᴰ : ∀ {x xᴰ} (p : ⟨ P ⟅ x ⟆ ⟩)
         → Pᴰ.p[ p ][ xᴰ ]
         → D [ intro p ][ xᴰ , vertexᴰ ]
     introᴰ p pᴰ = ∫ue.intro (p , pᴰ) .snd
+    opaque
+      unfolding β
+      βᴰ : ∀ {x xᴰ} {p : Pᴰ.pob[ x ] } {pᴰ : Pᴰ.p[ p ][ xᴰ ]}
+           → (introᴰ p pᴰ Pᴰ.⋆ᴰ elementᴰ) Pᴰ.≡[ β ] pᴰ
+      βᴰ = cong snd ∫ue.β
 
-    βᴰ : ∀ {x xᴰ} {p : Pᴰ.pob[ x ] } {pᴰ : Pᴰ.p[ p ][ xᴰ ]}
-         → (introᴰ p pᴰ Pᴰ.⋆ᴰ elementᴰ) Pᴰ.≡[ β ] pᴰ
-    βᴰ = cong snd ∫ue.β
+      ηᴰ : ∀ {x xᴰ} {f : C [ x , vertex ]} {fᴰ : D [ f ][ xᴰ , vertexᴰ ]}
+           → fᴰ D.≡[ η {f = f} ] (introᴰ _ (fᴰ Pᴰ.⋆ᴰ elementᴰ))
+      ηᴰ = R.rectify $ cong snd ∫ue.η
 
-    ηᴰ : ∀ {x xᴰ} {f : C [ x , vertex ]} {fᴰ : D [ f ][ xᴰ , vertexᴰ ]}
-         → fᴰ D.≡[ η {f = f} ] (introᴰ _ (F-homᴰ Pᴰ fᴰ element elementᴰ))
-    ηᴰ = R.rectify $ cong snd ∫ue.η
+      weak-ηᴰ : D.idᴰ D.≡[ weak-η ] introᴰ _ elementᴰ
+      weak-ηᴰ = R.rectify $ cong snd ∫ue.weak-η
 
-    weak-ηᴰ : D.idᴰ D.≡[ weak-η ] introᴰ _ elementᴰ
-    weak-ηᴰ = R.rectify $ cong snd ∫ue.weak-η
+      extensionalityᴰ
+        : ∀ {x xᴰ} {f g : C [ x , vertex ]}
+          {fᴰ : D [ f ][ xᴰ , vertexᴰ ]}
+          {gᴰ : D [ g ][ xᴰ , vertexᴰ ]}
+        → (fπ≡gπ : f P.⋆ element  ≡ g P.⋆ element)
+        → (fᴰ Pᴰ.⋆ᴰ elementᴰ) Pᴰ.≡[ fπ≡gπ ] (gᴰ Pᴰ.⋆ᴰ elementᴰ)
+        → fᴰ D.≡[ extensionality fπ≡gπ ] gᴰ
+      extensionalityᴰ fπ≡gπ p = R.rectify $
+        cong snd (∫ue.extensionality (ΣPathP (fπ≡gπ , p)))
 
-    extensionalityᴰ
-      : ∀ {x xᴰ} {f g : C [ x , vertex ]}
-        {fᴰ : D [ f ][ xᴰ , vertexᴰ ]}
-        {gᴰ : D [ g ][ xᴰ , vertexᴰ ]}
-      → (fπ≡gπ : element ∘ᴾ⟨ C , P ⟩ f ≡ element ∘ᴾ⟨ C , P ⟩ g)
-      → (fᴰ Pᴰ.⋆ᴰ elementᴰ) Pᴰ.≡[ fπ≡gπ ] (gᴰ Pᴰ.⋆ᴰ elementᴰ)
-      → fᴰ D.≡[ extensionality fπ≡gπ ] gᴰ
-    extensionalityᴰ fπ≡gπ p = R.rectify $
-      cong snd (∫ue.extensionality (ΣPathP (fπ≡gπ , p)))
+      introᴰ-natural : ∀ {x y}{f : C [ x , y ]}{p : P.p[ y ]}
+        {xᴰ yᴰ}{fᴰ : D [ f ][ xᴰ , yᴰ ]}{pᴰ : Pᴰ.p[ p ][ yᴰ ]}
+        → (fᴰ D.⋆ᴰ introᴰ _ pᴰ) D.≡[ intro-natural ] introᴰ _ (fᴰ Pᴰ.⋆ᴰ pᴰ)
+      introᴰ-natural = R.rectify $ cong snd (∫ue.intro-natural)
 
 -- A vertical presheaf is a displayed presheaf over a representable
 Presheafⱽ : {C : Category ℓC ℓC'} (D : Categoryᴰ C ℓD ℓD')

--- a/Cubical/Categories/FunctorComprehension.agda
+++ b/Cubical/Categories/FunctorComprehension.agda
@@ -1,0 +1,70 @@
+{-# OPTIONS --safe --lossy-unification #-}
+{--
+ -- Functor Comprehension
+ -- ======================
+ -- This module provides a method for constructing functors by showing
+ -- that they have a universal property.
+ --
+ -- The idea is that if you wish to define a functor F : C → D via a
+ -- universal property (P c), then the functoriality of F comes for
+ -- free if the universal property P is given functorially, that is if
+ -- P is a functor P : C → Psh D
+ --
+ -- That is, if you construct for each c a universal element of P c,
+ -- then this can be *uniquely* extended to a functorial action on
+ -- morphisms, and furthermore you get that the universal elements so
+ -- constructed are natural with respect to this functorial action.
+ -- We provide this data in this module in two equivalent forms:
+ -- 1. A "natural element" ∀ c → P c (F c)
+ -- 2. A natural isomorphism (Y ∘ F ≅ P)
+ --
+ -- The fact is essentially a corollary of the Yoneda lemma, but we
+ --
+ -- Constructing a functor in this method saves a lot of work in
+ -- repeatedly demonstrating functoriality
+ --
+ --}
+module Cubical.Categories.FunctorComprehension where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+open import Cubical.Categories.NaturalTransformation
+open import Cubical.Categories.Presheaf.Representable
+open import Cubical.Categories.Presheaf.More
+open import Cubical.Categories.Profunctor.General
+
+private
+  variable
+    ℓC ℓC' ℓD ℓD' ℓS ℓR : Level
+
+open Category
+open Functor
+open NatTrans
+open UniversalElement
+open UniversalElementNotation
+
+module _ {C : Category ℓC ℓC'}{D : Category ℓD ℓD'}
+         {P : Profunctor C D ℓS}
+         (ues : UniversalElements P)
+         where
+  private
+    module C = Category C
+  FunctorComprehension : Functor C D
+  FunctorComprehension .F-ob x = ues x .vertex
+  FunctorComprehension .F-hom {x}{y} f =
+    intro (ues y) ((P ⟪ f ⟫) .N-ob _ (ues x .element))
+  FunctorComprehension .F-id {x} =
+    (λ i → intro (ues x) (P .F-id i .N-ob _ (ues x .element)))
+    ∙ (sym $ weak-η (ues x))
+  FunctorComprehension .F-seq {x}{y}{z} f g =
+    ((λ i → intro (ues z) (P .F-seq f g i .N-ob _ (ues x .element))))
+    ∙ (cong (intro (ues z)) $
+      ((λ i → P .F-hom g .N-ob _
+        (β (ues y) {p = P .F-hom f .N-ob _ (ues x .element)} (~ i))))
+      ∙ funExt⁻ (P .F-hom g .N-hom _) _)
+    ∙ (sym $ intro-natural (ues z))

--- a/Cubical/Categories/Limits/BinProduct/More.agda
+++ b/Cubical/Categories/Limits/BinProduct/More.agda
@@ -131,9 +131,9 @@ module _ (C : Category ℓ ℓ') where
 
     -- test definitional behavior
     _ : ∀ {b b'}(f : C [ b , b' ]) →
-        BinProductWithF ⟪ f ⟫ ≡
-          bp b' .univProp (bp b .binProdPr₁)
-            (f ∘⟨ C ⟩ bp b .binProdPr₂) .fst .fst
+          BinProductWithF ⟪ f ⟫ ≡
+            bp b' .univProp (bp b .binProdPr₁)
+              (f ∘⟨ C ⟩ bp b .binProdPr₂) .fst .fst
     _ = λ f → refl
     module ProdsWithNotation where
       open UniversalElementNotation {C = C}

--- a/Cubical/Categories/Presheaf/More.agda
+++ b/Cubical/Categories/Presheaf/More.agda
@@ -93,7 +93,7 @@ module PresheafNotation {ℓo}{ℓh}
   ⋆Assoc f g = funExt⁻ (P .F-seq g f)
 
   ⟨_⟩⋆⟨_⟩ : ∀ {x y} {f f' : C [ x , y ]} {g g' : p[ y ]}
-          → f ≡ f' → g ≡ g' → f ⋆ g ≡ f' ⋆ g'
+            → f ≡ f' → g ≡ g' → f ⋆ g ≡ f' ⋆ g'
   ⟨ f≡f' ⟩⋆⟨ g≡g' ⟩ = cong₂ _⋆_ f≡f' g≡g'
 
 module UniversalElementNotation {ℓo}{ℓh}
@@ -118,26 +118,31 @@ module UniversalElementNotation {ℓo}{ℓh}
   universalIso : ∀ (c : C .ob) → Iso (C [ c , vertex ]) ⟨ P ⟅ c ⟆ ⟩
   universalIso c = equivToIso (_ , universal c)
 
-  intro : ∀ {c} → ⟨ P ⟅ c ⟆ ⟩ → C [ c , vertex ]
+  private
+    module P = PresheafNotation P
+    module C = Category C
+
+  intro : ∀ {c} → P.p[ c ] → C [ c , vertex ]
   intro = universalIso _ .inv
 
-  β : ∀ {c} → {p : ⟨ P ⟅ c ⟆ ⟩} → (element ∘ᴾ⟨ C , P ⟩ intro p) ≡ p
-  β = universalIso _ .rightInv _
+  opaque
+    β : ∀ {c} → {p : P.p[ c ]} → (intro p P.⋆ element) ≡ p
+    β = universalIso _ .rightInv _
 
-  η : ∀ {c} → {f : C [ c , vertex ]} → f ≡ intro (element ∘ᴾ⟨ C , P ⟩ f)
-  η {f = f} = sym (universalIso _ .leftInv _)
+    η : ∀ {c} → {f : C [ c , vertex ]} → f ≡ intro (f P.⋆ element)
+    η {f = f} = sym (universalIso _ .leftInv _)
 
-  weak-η : C .id ≡ intro element
-  weak-η = η ∙ cong intro (∘ᴾId C P _)
+    weak-η : C .id ≡ intro element
+    weak-η = η ∙ cong intro (∘ᴾId C P _)
 
-  extensionality : ∀ {c} → {f f' : C [ c , vertex ]}
-                 → (element ∘ᴾ⟨ C , P ⟩ f) ≡ (element ∘ᴾ⟨ C , P ⟩ f')
-                 → f ≡ f'
-  extensionality = isoFunInjective (equivToIso (_ , (universal _))) _ _
+    extensionality : ∀ {c} → {f f' : C [ c , vertex ]}
+                   → (f P.⋆ element) ≡ (f' P.⋆ element)
+                   → f ≡ f'
+    extensionality = isoFunInjective (equivToIso (_ , (universal _))) _ _
 
-  intro-natural : ∀ {c' c} → {p : ⟨ P ⟅ c ⟆ ⟩}{f : C [ c' , c ]}
-                → intro p ∘⟨ C ⟩ f ≡ intro (p ∘ᴾ⟨ C , P ⟩ f)
-  intro-natural = extensionality
-    ( (∘ᴾAssoc C P _ _ _
-    ∙ cong (action C P _) β)
-    ∙ sym β)
+    intro-natural : ∀ {c' c} → {p : P.p[ c ]}{f : C [ c' , c ]}
+                  → f C.⋆ intro p ≡ intro (f P.⋆ p)
+    intro-natural = extensionality
+      ( (∘ᴾAssoc C P _ _ _
+      ∙ cong (action C P _) β)
+      ∙ sym β)

--- a/Cubical/Categories/Presheaf/More.agda
+++ b/Cubical/Categories/Presheaf/More.agda
@@ -21,7 +21,6 @@ open import Cubical.Categories.Presheaf.Representable
 open import Cubical.Categories.Instances.Sets.More
 open import Cubical.Categories.Isomorphism.More
 
-open Category
 open Functor
 
 private
@@ -45,7 +44,7 @@ IdPshIso C P = idCatIso
 𝓟* : Category ℓ ℓ' → (ℓS : Level) → Type (ℓ-max (ℓ-max ℓ ℓ') (ℓ-suc ℓS))
 𝓟* C ℓS = Functor C (SET ℓS)
 
-module _ (C : Category ℓ ℓ') (c : C .ob) where
+module _ (C : Category ℓ ℓ') (c : C .Category.ob) where
   open Category
   open UniversalElement
 
@@ -65,7 +64,7 @@ module _ (C : Category ℓ ℓ') (c : C .ob) where
 
 module _ {ℓo}{ℓh}{ℓp} (C : Category ℓo ℓh) (P : Presheaf C ℓp) where
   open UniversalElement
-
+  open Category
   UniversalElementOn : C .ob → Type (ℓ-max (ℓ-max ℓo ℓh) ℓp)
   UniversalElementOn vertex =
     Σ[ element ∈ (P ⟅ vertex ⟆) .fst ] isUniversal C P vertex element
@@ -75,10 +74,33 @@ module _ {ℓo}{ℓh}{ℓp} (C : Category ℓo ℓh) (P : Presheaf C ℓp) where
   UniversalElementToUniversalElementOn ue .fst = ue .element
   UniversalElementToUniversalElementOn ue .snd = ue .universal
 
+module PresheafNotation {ℓo}{ℓh}
+       {C : Category ℓo ℓh} {ℓp} (P : Presheaf C ℓp)
+       where
+  private
+    module C = Category C
+  p[_] : C.ob → Type ℓp
+  p[ x ] = ⟨ P ⟅ x ⟆ ⟩
+
+  _⋆_ : ∀ {x y} (f : C [ x , y ]) (g : p[ y ]) → p[ x ]
+  f ⋆ g = P .F-hom f g
+
+  ⋆IdL : ∀ {x} (g : p[ x ]) → C.id ⋆ g ≡ g
+  ⋆IdL = funExt⁻ (P .F-id)
+
+  ⋆Assoc : ∀ {x y z} (f : C [ x , y ])(g : C [ y , z ])(h : p[ z ]) →
+    (f C.⋆ g) ⋆ h ≡ f ⋆ (g ⋆ h)
+  ⋆Assoc f g = funExt⁻ (P .F-seq g f)
+
+  ⟨_⟩⋆⟨_⟩ : ∀ {x y} {f f' : C [ x , y ]} {g g' : p[ y ]}
+          → f ≡ f' → g ≡ g' → f ⋆ g ≡ f' ⋆ g'
+  ⟨ f≡f' ⟩⋆⟨ g≡g' ⟩ = cong₂ _⋆_ f≡f' g≡g'
+
 module UniversalElementNotation {ℓo}{ℓh}
        {C : Category ℓo ℓh} {ℓp} {P : Presheaf C ℓp}
        (ue : UniversalElement C P)
        where
+  open Category
   open UniversalElement ue public
   open NatTrans
   open NatIso


### PR DESCRIPTION
Wrote a direct construction of functor comprehension that type checks much faster. Should speed up re-checking of the library overall (though not CI currently because I haven't removed the slow modules)

Also adds PresheafNotation, extends Presheaf^DNotation, makes many presheaf reasoning equations opaque