### PR TITLE
Displayed exponentials, Simpler Functor Comprehension, Displayed Bifunctors, PresheafNotation

### DIFF
--- a/Cubical/Categories/Bifunctor/Redundant.agda
+++ b/Cubical/Categories/Bifunctor/Redundant.agda
@@ -566,3 +566,14 @@ _^opBif {C = C}{D = D}{E = E} F = mkBifunctorParAx G where
   G .Bif-×-seq f f' g g' = F.Bif-×-seq f' f g' g
   G .Bif-L×-agree = F.Bif-L×-agree
   G .Bif-R×-agree = F.Bif-R×-agree
+
+-- This probably should go somewhere else
+,F-Bif : Bifunctor (FUNCTOR C C') (FUNCTOR C D') (FUNCTOR C (C' ×C D'))
+,F-Bif {C' = C'}{D' = D'} = mkBifunctorPar ,F' where
+  open BifunctorPar
+  ,F' : BifunctorPar (FUNCTOR _ _) (FUNCTOR _ _) (FUNCTOR _ _)
+  ,F' .Bif-ob = _,F_
+  ,F' .Bif-hom× α β .N-ob c = (α .N-ob c) , (β .N-ob c)
+  ,F' .Bif-hom× α β .N-hom f = ΣPathP (α .N-hom f , β .N-hom f)
+  ,F' .Bif-×-id = makeNatTransPath refl
+  ,F' .Bif-×-seq _ _ _ _ = makeNatTransPath refl

--- a/Cubical/Categories/Bifunctor/Redundant.agda
+++ b/Cubical/Categories/Bifunctor/Redundant.agda
@@ -566,14 +566,3 @@ _^opBif {C = C}{D = D}{E = E} F = mkBifunctorParAx G where
   G .Bif-×-seq f f' g g' = F.Bif-×-seq f' f g' g
   G .Bif-L×-agree = F.Bif-L×-agree
   G .Bif-R×-agree = F.Bif-R×-agree
-
--- This probably should go somewhere else
-,F-Bif : Bifunctor (FUNCTOR C C') (FUNCTOR C D') (FUNCTOR C (C' ×C D'))
-,F-Bif {C' = C'}{D' = D'} = mkBifunctorPar ,F' where
-  open BifunctorPar
-  ,F' : BifunctorPar (FUNCTOR _ _) (FUNCTOR _ _) (FUNCTOR _ _)
-  ,F' .Bif-ob = _,F_
-  ,F' .Bif-hom× α β .N-ob c = (α .N-ob c) , (β .N-ob c)
-  ,F' .Bif-hom× α β .N-hom f = ΣPathP (α .N-hom f , β .N-hom f)
-  ,F' .Bif-×-id = makeNatTransPath refl
-  ,F' .Bif-×-seq _ _ _ _ = makeNatTransPath refl

--- a/Cubical/Categories/Constructions/BinProduct/More.agda
+++ b/Cubical/Categories/Constructions/BinProduct/More.agda
@@ -13,6 +13,7 @@ open import Cubical.Categories.Functor.Base
 open import Cubical.Categories.Functors.Constant
 open import Cubical.Categories.NaturalTransformation
 open import Cubical.Categories.NaturalTransformation.More
+open import Cubical.Categories.Instances.Functors
 open import Cubical.Categories.Instances.Functors.More
 
 open import Cubical.Categories.Constructions.BinProduct
@@ -80,3 +81,11 @@ module _ {A : Category ℓA ℓA'}
     NatIso F F' → NatIso G G' → NatIso (F ×F G) (F' ×F G')
   NatIso× α β .trans = NatTrans× (α .trans) (β .trans)
   NatIso× α β .nIso (x , y) = CatIso× _ _ (NatIsoAt α x) (NatIsoAt β y) .snd
+
+open NatTrans
+,F-functor : Functor ((FUNCTOR C C') ×C (FUNCTOR C D')) (FUNCTOR C (C' ×C D'))
+,F-functor .F-ob (F , G) = F ,F G
+,F-functor .F-hom (α , β) .N-ob x = (α ⟦ x ⟧) , (β ⟦ x ⟧)
+,F-functor .F-hom (α , β) .N-hom f = ΣPathP ((α .N-hom f) , (β .N-hom f))
+,F-functor .F-id = makeNatTransPath refl
+,F-functor .F-seq f g = makeNatTransPath refl

--- a/Cubical/Categories/Constructions/Free/CartesianCategory/Base.agda
+++ b/Cubical/Categories/Constructions/Free/CartesianCategory/Base.agda
@@ -127,17 +127,17 @@ module _ (Q : ×Quiver ℓQ ℓQ') where
           (cong elim-F-hom p) (cong elim-F-hom q)
           i j
         elim-F-hom !ₑ = !tᴰ _
-        -- TODO: Why does this need rectify?
         elim-F-hom (⊤η f i) =
           R.rectify {p' = ⊤η f} (𝟙ηᴰ (elim-F-hom f)) i
         elim-F-hom π₁ = π₁ᴰ
         elim-F-hom π₂ = π₂ᴰ
         elim-F-hom ⟨ f₁ , f₂ ⟩ = elim-F-hom f₁ ,pᴰ elim-F-hom f₂
         elim-F-hom (×β₁ {t = f₁}{t' = f₂} i) =
-          ×β₁ᴰ {f₁ᴰ = elim-F-hom f₁} {f₂ᴰ = elim-F-hom f₂} i
+          R.rectify {p' = ×β₁}
+            ((×β₁ᴰ {f₁ᴰ = elim-F-hom f₁} {f₂ᴰ = elim-F-hom f₂})) i
         elim-F-hom (×β₂ {t = f₁}{t' = f₂} i) =
-          ×β₂ᴰ {f₁ᴰ = elim-F-hom f₁} {f₂ᴰ = elim-F-hom f₂} i
-        -- TODO: Why do we need this rectify too?
+          R.rectify {p' = ×β₂}
+            (×β₂ᴰ {f₁ᴰ = elim-F-hom f₁} {f₂ᴰ = elim-F-hom f₂}) i
         elim-F-hom (×η {t = f} i) =
           R.rectify {p' = ×η {t = f}} (×ηᴰ {fᴰ = elim-F-hom f}) i
 

--- a/Cubical/Categories/Displayed/Bifunctor.agda
+++ b/Cubical/Categories/Displayed/Bifunctor.agda
@@ -8,6 +8,7 @@ open import Cubical.Categories.Category
 open import Cubical.Categories.Functor
 open import Cubical.Categories.NaturalTransformation
 open import Cubical.Categories.Constructions.BinProduct hiding (Fst; Snd; Sym)
+import Cubical.Categories.Constructions.TotalCategory as ∫
 open import Cubical.Categories.Instances.Sets
 open import Cubical.Categories.Instances.Functors
 open import Cubical.Categories.Bifunctor.Redundant
@@ -43,7 +44,7 @@ module _ {C : Category ℓC ℓC'}
       module F = Bifunctor F
   
     field
-      Bif-obᴰ : ∀ {c d} → Cᴰ.ob[ c ] → Dᴰ.ob[ d ] → Eᴰ.ob[ F ⟅ c , d ⟆b ]
+      Bif-obᴰ : ∀ {c d} → (cᴰ : Cᴰ.ob[ c ]) → (dᴰ : Dᴰ.ob[ d ]) → Eᴰ.ob[ F ⟅ c , d ⟆b ]
       Bif-homLᴰ : ∀ {c c' cᴰ cᴰ'} {f : C [ c , c' ]} (fᴰ : Cᴰ [ f ][ cᴰ , cᴰ' ])
         {d} (dᴰ : Dᴰ.ob[ d ])
         → Eᴰ [ F ⟪ f ⟫l ][ Bif-obᴰ cᴰ dᴰ , Bif-obᴰ cᴰ' dᴰ ]
@@ -98,6 +99,28 @@ private
   variable
     C D E C' D' E' : Category ℓ ℓ'
     Cᴰ Dᴰ Eᴰ Cᴰ' Dᴰ' Eᴰ' : Categoryᴰ C ℓ ℓ'
+
+module _ {F : Bifunctor C D E} (Fᴰ : Bifunctorᴰ F Cᴰ Dᴰ Eᴰ) where
+  private
+    module Eᴰ = Reasoning Eᴰ
+  ∫Bif : Bifunctor (∫.∫C Cᴰ) (∫.∫C Dᴰ) (∫.∫C Eᴰ)
+  ∫Bif = mkBifunctorParAx ∫BifParAx where
+    open BifunctorParAx
+    ∫BifParAx : BifunctorParAx (∫.∫C Cᴰ) (∫.∫C Dᴰ) (∫.∫C Eᴰ)
+    ∫BifParAx .Bif-ob (c , cᴰ) (d , dᴰ) =
+      (Bifunctor.Bif-ob F c d) , (Fᴰ .Bifunctorᴰ.Bif-obᴰ cᴰ dᴰ)
+    ∫BifParAx .Bif-homL (f , fᴰ) (d , dᴰ) =
+      (Bifunctor.Bif-homL F f d) , (Fᴰ .Bifunctorᴰ.Bif-homLᴰ fᴰ dᴰ)
+    ∫BifParAx .Bif-homR (c , cᴰ) (g , gᴰ) =
+      (Bifunctor.Bif-homR F c g) , (Fᴰ .Bifunctorᴰ.Bif-homRᴰ cᴰ gᴰ)
+    ∫BifParAx .Bif-hom× (f , fᴰ) (g , gᴰ) =
+      (Bifunctor.Bif-hom× F f g) , (Fᴰ .Bifunctorᴰ.Bif-hom×ᴰ fᴰ gᴰ)
+    ∫BifParAx .Bif-×-id = Eᴰ.≡in $ (Fᴰ .Bifunctorᴰ.Bif-×-idᴰ) 
+    ∫BifParAx .Bif-×-seq (f , fᴰ) (f' , fᴰ') (g , gᴰ) (g' , gᴰ') =
+      Eᴰ.≡in $ Fᴰ .Bifunctorᴰ.Bif-×-seqᴰ fᴰ fᴰ' gᴰ gᴰ'
+    ∫BifParAx .Bif-L×-agree (f , fᴰ) = Eᴰ.≡in $ Fᴰ .Bifunctorᴰ.Bif-L×-agreeᴰ fᴰ
+    ∫BifParAx .Bif-R×-agree (g , gᴰ) = Eᴰ.≡in $ Fᴰ .Bifunctorᴰ.Bif-R×-agreeᴰ gᴰ
+
 open Category
 open Categoryᴰ
 open Functorᴰ
@@ -108,6 +131,17 @@ appLᴰ Fᴰ cᴰ .F-obᴰ dᴰ = Fᴰ .Bif-obᴰ cᴰ dᴰ
 appLᴰ Fᴰ cᴰ .F-homᴰ gᴰ = Fᴰ .Bif-homRᴰ cᴰ gᴰ
 appLᴰ Fᴰ cᴰ .F-idᴰ = Bif-R-idᴰ Fᴰ
 appLᴰ Fᴰ cᴰ .Functorᴰ.F-seqᴰ = Bif-R-seqᴰ Fᴰ
+
+appRᴰ : {F : Bifunctor C D E} (Fᴰ : Bifunctorᴰ F Cᴰ Dᴰ Eᴰ)
+  {d : D .ob} (dᴰ : ob[_] Dᴰ d) → Functorᴰ (appR F d) Cᴰ Eᴰ
+appRᴰ {Eᴰ = Eᴰ}{F = F} Fᴰ dᴰ = record
+  { F-obᴰ = λ xᴰ → ∫appR .F-ob (_ , xᴰ) .snd
+  ; F-homᴰ = λ fᴰ → ∫appR .F-hom (_ , fᴰ) .snd
+  ; F-idᴰ = R.rectify $ λ i → ∫appR .F-id i .snd  -- R.≡out {!λ i → ∫appR .F-id i .snd!}
+  ; F-seqᴰ = λ fᴰ gᴰ → R.rectify $ λ i → ∫appR .F-seq (_ , fᴰ) (_ , gᴰ) i .snd  } where
+  open Functor
+  module R = Reasoning Eᴰ
+  ∫appR = appR (∫Bif Fᴰ) (_ , dᴰ)
 
 module _ {F : Bifunctor C' D E} {G : Functor C C'}
   (Fᴰ : Bifunctorᴰ F Cᴰ' Dᴰ Eᴰ) (Gᴰ : Functorᴰ G Cᴰ Cᴰ') where
@@ -130,8 +164,42 @@ module _ {F : Bifunctor C' D E} {G : Functor C C'}
     (Eᴰ.≡in $ Fᴰ .Bif-R×-agreeᴰ _)
     ∙ (Eᴰ.≡in $ λ i → Fᴰ .Bif-hom×ᴰ (Gᴰ .F-idᴰ (~ i)) gᴰ)
 
+module _ {F : Bifunctor C D' E} {G : Functor D D'}
+  (Fᴰ : Bifunctorᴰ F Cᴰ Dᴰ' Eᴰ) (Gᴰ : Functorᴰ G Dᴰ Dᴰ') where
+  private
+    module Eᴰ = Reasoning Eᴰ
+    ∫compRᴰ = compR (∫Bif Fᴰ) (∫.∫F Gᴰ)
+    module ∫compRᴰ = Bifunctor ∫compRᴰ
+  compRᴰ : Bifunctorᴰ (compR F G) Cᴰ Dᴰ Eᴰ
+  compRᴰ .Bif-obᴰ cᴰ dᴰ = ∫compRᴰ.Bif-ob (_ , cᴰ) (_ , dᴰ) .snd
+  compRᴰ .Bif-homLᴰ fᴰ dᴰ = ∫compRᴰ.Bif-homL (_ , fᴰ) (_ , dᴰ) .snd
+  compRᴰ .Bif-homRᴰ cᴰ gᴰ = ∫compRᴰ.Bif-homR (_ , cᴰ) (_ , gᴰ) .snd
+  compRᴰ .Bif-hom×ᴰ fᴰ gᴰ = ∫compRᴰ.Bif-hom× (_ , fᴰ) (_ , gᴰ) .snd
+  compRᴰ .Bif-×-idᴰ = Eᴰ.rectify $ λ i → ∫compRᴰ.Bif-×-id i .snd
+  compRᴰ .Bif-×-seqᴰ fᴰ fᴰ' gᴰ gᴰ' = Eᴰ.rectify $ λ i → ∫compRᴰ.Bif-×-seq (_ , fᴰ) (_ , fᴰ') (_ , gᴰ) (_ , gᴰ') i .snd
+  compRᴰ .Bif-L×-agreeᴰ fᴰ = Eᴰ.rectify $ λ i → ∫compRᴰ.Bif-L×-agree (_ , fᴰ) i .snd
+  compRᴰ .Bif-R×-agreeᴰ gᴰ = Eᴰ.rectify $ λ i → ∫compRᴰ.Bif-R×-agree (_ , gᴰ) i .snd
+
+module _ {F : Functor E E'}{G : Bifunctor C D E}
+       (Fᴰ : Functorᴰ F Eᴰ Eᴰ')(Gᴰ : Bifunctorᴰ G Cᴰ Dᴰ Eᴰ)
+  where
+  private
+    module Eᴰ' = Reasoning Eᴰ'
+    ∫compFᴰ = compF (∫.∫F Fᴰ) (∫Bif Gᴰ)
+    module ∫compFᴰ = Bifunctor ∫compFᴰ
+  compFᴰ : Bifunctorᴰ (compF F G) Cᴰ Dᴰ Eᴰ'
+  compFᴰ .Bif-obᴰ cᴰ dᴰ = ∫compFᴰ.Bif-ob (_ , cᴰ) (_ , dᴰ) .snd
+  compFᴰ .Bif-homLᴰ fᴰ dᴰ = ∫compFᴰ.Bif-homL (_ , fᴰ) (_ , dᴰ) .snd
+  compFᴰ .Bif-homRᴰ cᴰ gᴰ = ∫compFᴰ.Bif-homR (_ , cᴰ) (_ , gᴰ) .snd
+  compFᴰ .Bif-hom×ᴰ fᴰ gᴰ = ∫compFᴰ.Bif-hom× (_ , fᴰ) (_ , gᴰ) .snd
+  compFᴰ .Bif-×-idᴰ = Eᴰ'.rectify $ λ i → ∫compFᴰ.Bif-×-id i .snd
+  compFᴰ .Bif-×-seqᴰ fᴰ fᴰ' gᴰ gᴰ' =
+    Eᴰ'.rectify $ λ i → ∫compFᴰ.Bif-×-seq (_ , fᴰ) (_ , fᴰ') (_ , gᴰ) (_ , gᴰ') i .snd
+  compFᴰ .Bif-L×-agreeᴰ fᴰ = Eᴰ'.rectify $ λ i → ∫compFᴰ.Bif-L×-agree (_ , fᴰ) i .snd
+  compFᴰ .Bif-R×-agreeᴰ gᴰ = Eᴰ'.rectify $ λ i → ∫compFᴰ.Bif-R×-agree (_ , gᴰ) i .snd
+
 -- To implement:
--- 1. Compositions ∘Flᴰ , ∘Frᴰ , ∘Fbᴰ , ∘Flrᴰ
+-- 1. [x] Compositions ∘Flᴰ , ∘Frᴰ , ∘Fbᴰ , ∘Flrᴰ
 -- 2. [x] appL
 -- 3. BifunctorToParFunctor
 -- 2. ×SetsBifᴰ (SETᴰ)

--- a/Cubical/Categories/Displayed/Bifunctor.agda
+++ b/Cubical/Categories/Displayed/Bifunctor.agda
@@ -224,19 +224,3 @@ module _ {F : Functor (C ×C D) E}
     Fᴰ .F-seqᴰ (fᴰ , gᴰ) (fᴰ' , gᴰ')
   ParFunctorᴰToBifunctorᴰ .Bif-L×-agreeᴰ fᴰ = refl
   ParFunctorᴰToBifunctorᴰ .Bif-R×-agreeᴰ gᴰ = refl
-
--- To implement:
--- 1. [x] Compositions ∘Flᴰ , ∘Frᴰ , ∘Fbᴰ , ∘Flrᴰ
--- 2. [x] appL
--- 3. [x] BifunctorToParFunctor
--- 2. ×Setsᴰ (SETᴰ)
--- 4. ,Fᴰ-functor    (×Cᴰ)
-,Fᴰ-Bif : Bifunctorᴰ ,F-Bif (FUNCTORᴰ Cᴰ Cᴰ') (FUNCTORᴰ Cᴰ Dᴰ') (FUNCTORᴰ Cᴰ (Cᴰ' ×Cᴰ Dᴰ'))
-,Fᴰ-Bif .Bif-obᴰ = {!!}
-,Fᴰ-Bif .Bif-homLᴰ = {!!}
-,Fᴰ-Bif .Bif-homRᴰ = {!!}
-,Fᴰ-Bif .Bif-hom×ᴰ = {!!}
-,Fᴰ-Bif .Bif-×-idᴰ = {!!}
-,Fᴰ-Bif .Bif-×-seqᴰ = {!!}
-,Fᴰ-Bif .Bif-L×-agreeᴰ = {!!}
-,Fᴰ-Bif .Bif-R×-agreeᴰ = {!!}

--- a/Cubical/Categories/Displayed/Bifunctor.agda
+++ b/Cubical/Categories/Displayed/Bifunctor.agda
@@ -96,8 +96,8 @@ module _ {C : Category ℓC ℓC'}
 
 private
   variable
-    C D E : Category ℓ ℓ'
-    Cᴰ Dᴰ Eᴰ : Categoryᴰ C ℓ ℓ'
+    C D E C' D' E' : Category ℓ ℓ'
+    Cᴰ Dᴰ Eᴰ Cᴰ' Dᴰ' Eᴰ' : Categoryᴰ C ℓ ℓ'
 open Category
 open Categoryᴰ
 open Functorᴰ
@@ -108,6 +108,27 @@ appLᴰ Fᴰ cᴰ .F-obᴰ dᴰ = Fᴰ .Bif-obᴰ cᴰ dᴰ
 appLᴰ Fᴰ cᴰ .F-homᴰ gᴰ = Fᴰ .Bif-homRᴰ cᴰ gᴰ
 appLᴰ Fᴰ cᴰ .F-idᴰ = Bif-R-idᴰ Fᴰ
 appLᴰ Fᴰ cᴰ .Functorᴰ.F-seqᴰ = Bif-R-seqᴰ Fᴰ
+
+module _ {F : Bifunctor C' D E} {G : Functor C C'}
+  (Fᴰ : Bifunctorᴰ F Cᴰ' Dᴰ Eᴰ) (Gᴰ : Functorᴰ G Cᴰ Cᴰ') where
+  private
+    module Dᴰ = Categoryᴰ Dᴰ
+    module Eᴰ = Reasoning Eᴰ
+  compLᴰ : Bifunctorᴰ (compL F G) Cᴰ Dᴰ Eᴰ
+  compLᴰ .Bif-obᴰ x = Fᴰ .Bif-obᴰ (F-obᴰ Gᴰ x)
+  compLᴰ .Bif-homLᴰ fᴰ dᴰ = Fᴰ .Bif-homLᴰ (F-homᴰ Gᴰ fᴰ) dᴰ
+  compLᴰ .Bif-homRᴰ cᴰ gᴰ = Fᴰ .Bif-homRᴰ (F-obᴰ Gᴰ cᴰ) gᴰ
+  compLᴰ .Bif-hom×ᴰ fᴰ gᴰ = Fᴰ .Bif-hom×ᴰ (F-homᴰ Gᴰ fᴰ) gᴰ
+  compLᴰ .Bif-×-idᴰ = Eᴰ.rectify $ Eᴰ.≡out $
+    (Eᴰ.≡in $ λ i → Fᴰ .Bif-hom×ᴰ (Gᴰ .F-idᴰ i) Dᴰ.idᴰ)
+    ∙ (Eᴰ.≡in $ Fᴰ .Bif-×-idᴰ)
+  compLᴰ .Bif-×-seqᴰ fᴰ fᴰ' gᴰ gᴰ' = Eᴰ.rectify $ Eᴰ.≡out $
+    (Eᴰ.≡in $ (λ i → Fᴰ .Bif-hom×ᴰ (Gᴰ .F-seqᴰ fᴰ fᴰ' i) (gᴰ Dᴰ.⋆ᴰ gᴰ')))
+    ∙ (Eᴰ.≡in $ Fᴰ .Bif-×-seqᴰ _ _ _ _)
+  compLᴰ .Bif-L×-agreeᴰ fᴰ = Eᴰ.rectify $ Fᴰ .Bif-L×-agreeᴰ _
+  compLᴰ .Bif-R×-agreeᴰ gᴰ = Eᴰ.rectify $ Eᴰ.≡out $
+    (Eᴰ.≡in $ Fᴰ .Bif-R×-agreeᴰ _)
+    ∙ (Eᴰ.≡in $ λ i → Fᴰ .Bif-hom×ᴰ (Gᴰ .F-idᴰ (~ i)) gᴰ)
 
 -- To implement:
 -- 1. Compositions ∘Flᴰ , ∘Frᴰ , ∘Fbᴰ , ∘Flrᴰ

--- a/Cubical/Categories/Displayed/Bifunctor.agda
+++ b/Cubical/Categories/Displayed/Bifunctor.agda
@@ -46,7 +46,8 @@ module _ {C : Category ℓC ℓC'}
       module F = Bifunctor F
 
     field
-      Bif-obᴰ : ∀ {c d} → (cᴰ : Cᴰ.ob[ c ]) → (dᴰ : Dᴰ.ob[ d ]) → Eᴰ.ob[ F ⟅ c , d ⟆b ]
+      Bif-obᴰ : ∀ {c d} → (cᴰ : Cᴰ.ob[ c ]) → (dᴰ : Dᴰ.ob[ d ])
+        → Eᴰ.ob[ F ⟅ c , d ⟆b ]
       Bif-homLᴰ : ∀ {c c' cᴰ cᴰ'} {f : C [ c , c' ]} (fᴰ : Cᴰ [ f ][ cᴰ , cᴰ' ])
         {d} (dᴰ : Dᴰ.ob[ d ])
         → Eᴰ [ F ⟪ f ⟫l ][ Bif-obᴰ cᴰ dᴰ , Bif-obᴰ cᴰ' dᴰ ]
@@ -87,7 +88,8 @@ module _ {C : Category ℓC ℓC'}
     Bif-R-idᴰ = R.rectify (R.≡out (R.≡in (Bif-R×-agreeᴰ _) ∙ R.≡in Bif-×-idᴰ))
 
     Bif-R-seqᴰ : ∀ {c d d' d''}{g : D [ d , d' ]}{g' : D [ d' , d'' ]}
-                  {cᴰ : Cᴰ.ob[ c ]}{dᴰ dᴰ' dᴰ''}(gᴰ : Dᴰ [ g ][ dᴰ , dᴰ' ])(gᴰ' : Dᴰ [ g' ][ dᴰ' , dᴰ'' ])
+                  {cᴰ : Cᴰ.ob[ c ]}{dᴰ dᴰ' dᴰ''}
+                  (gᴰ : Dᴰ [ g ][ dᴰ , dᴰ' ])(gᴰ' : Dᴰ [ g' ][ dᴰ' , dᴰ'' ])
               → Bif-homRᴰ cᴰ (gᴰ Dᴰ.⋆ᴰ gᴰ')
                   Eᴰ.≡[ F.Bif-R-seq g g' ]
                 Bif-homRᴰ cᴰ gᴰ Eᴰ.⋆ᴰ Bif-homRᴰ cᴰ gᴰ'

--- a/Cubical/Categories/Displayed/Bifunctor.agda
+++ b/Cubical/Categories/Displayed/Bifunctor.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --safe #-}
+{-# OPTIONS --safe --lossy-unification #-}
 module Cubical.Categories.Displayed.Bifunctor where
 
 open import Cubical.Foundations.Prelude
@@ -15,6 +15,8 @@ open import Cubical.Categories.Bifunctor.Redundant
 
 open import Cubical.Categories.Displayed.Base
 open import Cubical.Categories.Displayed.Functor
+open import Cubical.Categories.Displayed.BinProduct
+open import Cubical.Categories.Displayed.Instances.Functor
 import Cubical.Categories.Displayed.Reasoning as Reasoning
 
 open import Cubical.Data.Sigma
@@ -42,7 +44,7 @@ module _ {C : Category ℓC ℓC'}
       module Eᴰ = Categoryᴰ Eᴰ
       module R = Reasoning Eᴰ
       module F = Bifunctor F
-  
+
     field
       Bif-obᴰ : ∀ {c d} → (cᴰ : Cᴰ.ob[ c ]) → (dᴰ : Dᴰ.ob[ d ]) → Eᴰ.ob[ F ⟅ c , d ⟆b ]
       Bif-homLᴰ : ∀ {c c' cᴰ cᴰ'} {f : C [ c , c' ]} (fᴰ : Cᴰ [ f ][ cᴰ , cᴰ' ])
@@ -115,7 +117,7 @@ module _ {F : Bifunctor C D E} (Fᴰ : Bifunctorᴰ F Cᴰ Dᴰ Eᴰ) where
       (Bifunctor.Bif-homR F c g) , (Fᴰ .Bifunctorᴰ.Bif-homRᴰ cᴰ gᴰ)
     ∫BifParAx .Bif-hom× (f , fᴰ) (g , gᴰ) =
       (Bifunctor.Bif-hom× F f g) , (Fᴰ .Bifunctorᴰ.Bif-hom×ᴰ fᴰ gᴰ)
-    ∫BifParAx .Bif-×-id = Eᴰ.≡in $ (Fᴰ .Bifunctorᴰ.Bif-×-idᴰ) 
+    ∫BifParAx .Bif-×-id = Eᴰ.≡in $ (Fᴰ .Bifunctorᴰ.Bif-×-idᴰ)
     ∫BifParAx .Bif-×-seq (f , fᴰ) (f' , fᴰ') (g , gᴰ) (g' , gᴰ') =
       Eᴰ.≡in $ Fᴰ .Bifunctorᴰ.Bif-×-seqᴰ fᴰ fᴰ' gᴰ gᴰ'
     ∫BifParAx .Bif-L×-agree (f , fᴰ) = Eᴰ.≡in $ Fᴰ .Bifunctorᴰ.Bif-L×-agreeᴰ fᴰ
@@ -137,8 +139,10 @@ appRᴰ : {F : Bifunctor C D E} (Fᴰ : Bifunctorᴰ F Cᴰ Dᴰ Eᴰ)
 appRᴰ {Eᴰ = Eᴰ}{F = F} Fᴰ dᴰ = record
   { F-obᴰ = λ xᴰ → ∫appR .F-ob (_ , xᴰ) .snd
   ; F-homᴰ = λ fᴰ → ∫appR .F-hom (_ , fᴰ) .snd
-  ; F-idᴰ = R.rectify $ λ i → ∫appR .F-id i .snd  -- R.≡out {!λ i → ∫appR .F-id i .snd!}
-  ; F-seqᴰ = λ fᴰ gᴰ → R.rectify $ λ i → ∫appR .F-seq (_ , fᴰ) (_ , gᴰ) i .snd  } where
+  ; F-idᴰ =
+    R.rectify $ λ i → ∫appR .F-id i .snd
+  ; F-seqᴰ = λ fᴰ gᴰ → R.rectify $ λ i → ∫appR .F-seq (_ , fᴰ) (_ , gᴰ) i .snd
+  } where
   open Functor
   module R = Reasoning Eᴰ
   ∫appR = appR (∫Bif Fᴰ) (_ , dᴰ)
@@ -176,9 +180,12 @@ module _ {F : Bifunctor C D' E} {G : Functor D D'}
   compRᴰ .Bif-homRᴰ cᴰ gᴰ = ∫compRᴰ.Bif-homR (_ , cᴰ) (_ , gᴰ) .snd
   compRᴰ .Bif-hom×ᴰ fᴰ gᴰ = ∫compRᴰ.Bif-hom× (_ , fᴰ) (_ , gᴰ) .snd
   compRᴰ .Bif-×-idᴰ = Eᴰ.rectify $ λ i → ∫compRᴰ.Bif-×-id i .snd
-  compRᴰ .Bif-×-seqᴰ fᴰ fᴰ' gᴰ gᴰ' = Eᴰ.rectify $ λ i → ∫compRᴰ.Bif-×-seq (_ , fᴰ) (_ , fᴰ') (_ , gᴰ) (_ , gᴰ') i .snd
-  compRᴰ .Bif-L×-agreeᴰ fᴰ = Eᴰ.rectify $ λ i → ∫compRᴰ.Bif-L×-agree (_ , fᴰ) i .snd
-  compRᴰ .Bif-R×-agreeᴰ gᴰ = Eᴰ.rectify $ λ i → ∫compRᴰ.Bif-R×-agree (_ , gᴰ) i .snd
+  compRᴰ .Bif-×-seqᴰ fᴰ fᴰ' gᴰ gᴰ' = Eᴰ.rectify $ λ i →
+    ∫compRᴰ.Bif-×-seq (_ , fᴰ) (_ , fᴰ') (_ , gᴰ) (_ , gᴰ') i .snd
+  compRᴰ .Bif-L×-agreeᴰ fᴰ = Eᴰ.rectify $ λ i →
+    ∫compRᴰ.Bif-L×-agree (_ , fᴰ) i .snd
+  compRᴰ .Bif-R×-agreeᴰ gᴰ = Eᴰ.rectify $ λ i →
+    ∫compRᴰ.Bif-R×-agree (_ , gᴰ) i .snd
 
 module _ {F : Functor E E'}{G : Bifunctor C D E}
        (Fᴰ : Functorᴰ F Eᴰ Eᴰ')(Gᴰ : Bifunctorᴰ G Cᴰ Dᴰ Eᴰ)
@@ -193,14 +200,43 @@ module _ {F : Functor E E'}{G : Bifunctor C D E}
   compFᴰ .Bif-homRᴰ cᴰ gᴰ = ∫compFᴰ.Bif-homR (_ , cᴰ) (_ , gᴰ) .snd
   compFᴰ .Bif-hom×ᴰ fᴰ gᴰ = ∫compFᴰ.Bif-hom× (_ , fᴰ) (_ , gᴰ) .snd
   compFᴰ .Bif-×-idᴰ = Eᴰ'.rectify $ λ i → ∫compFᴰ.Bif-×-id i .snd
-  compFᴰ .Bif-×-seqᴰ fᴰ fᴰ' gᴰ gᴰ' =
-    Eᴰ'.rectify $ λ i → ∫compFᴰ.Bif-×-seq (_ , fᴰ) (_ , fᴰ') (_ , gᴰ) (_ , gᴰ') i .snd
-  compFᴰ .Bif-L×-agreeᴰ fᴰ = Eᴰ'.rectify $ λ i → ∫compFᴰ.Bif-L×-agree (_ , fᴰ) i .snd
-  compFᴰ .Bif-R×-agreeᴰ gᴰ = Eᴰ'.rectify $ λ i → ∫compFᴰ.Bif-R×-agree (_ , gᴰ) i .snd
+  compFᴰ .Bif-×-seqᴰ fᴰ fᴰ' gᴰ gᴰ' = Eᴰ'.rectify $ λ i →
+    ∫compFᴰ.Bif-×-seq (_ , fᴰ) (_ , fᴰ') (_ , gᴰ) (_ , gᴰ') i .snd
+  compFᴰ .Bif-L×-agreeᴰ fᴰ = Eᴰ'.rectify $ λ i →
+    ∫compFᴰ.Bif-L×-agree (_ , fᴰ) i .snd
+  compFᴰ .Bif-R×-agreeᴰ gᴰ = Eᴰ'.rectify $ λ i →
+    ∫compFᴰ.Bif-R×-agree (_ , gᴰ) i .snd
+
+
+module _ {F : Functor (C ×C D) E}
+         (Fᴰ : Functorᴰ F (Cᴰ ×Cᴰ Dᴰ) Eᴰ) where
+  private
+    module Cᴰ = Categoryᴰ Cᴰ
+    module Dᴰ = Categoryᴰ Dᴰ
+    module Eᴰ = Reasoning Eᴰ
+  ParFunctorᴰToBifunctorᴰ : Bifunctorᴰ (ParFunctorToBifunctor F) Cᴰ Dᴰ Eᴰ
+  ParFunctorᴰToBifunctorᴰ .Bif-obᴰ cᴰ dᴰ = Fᴰ .F-obᴰ (cᴰ , dᴰ)
+  ParFunctorᴰToBifunctorᴰ .Bif-homLᴰ fᴰ dᴰ = Fᴰ .F-homᴰ (fᴰ , Dᴰ.idᴰ)
+  ParFunctorᴰToBifunctorᴰ .Bif-homRᴰ cᴰ gᴰ = Fᴰ .F-homᴰ (Cᴰ.idᴰ , gᴰ)
+  ParFunctorᴰToBifunctorᴰ .Bif-hom×ᴰ fᴰ gᴰ = Fᴰ .F-homᴰ (fᴰ , gᴰ)
+  ParFunctorᴰToBifunctorᴰ .Bif-×-idᴰ = Fᴰ .F-idᴰ
+  ParFunctorᴰToBifunctorᴰ .Bif-×-seqᴰ fᴰ fᴰ' gᴰ gᴰ' =
+    Fᴰ .F-seqᴰ (fᴰ , gᴰ) (fᴰ' , gᴰ')
+  ParFunctorᴰToBifunctorᴰ .Bif-L×-agreeᴰ fᴰ = refl
+  ParFunctorᴰToBifunctorᴰ .Bif-R×-agreeᴰ gᴰ = refl
 
 -- To implement:
 -- 1. [x] Compositions ∘Flᴰ , ∘Frᴰ , ∘Fbᴰ , ∘Flrᴰ
 -- 2. [x] appL
--- 3. BifunctorToParFunctor
--- 2. ×SetsBifᴰ (SETᴰ)
--- 4. ,F-Bif    (×Cᴰ)
+-- 3. [x] BifunctorToParFunctor
+-- 2. ×Setsᴰ (SETᴰ)
+-- 4. ,Fᴰ-functor    (×Cᴰ)
+,Fᴰ-Bif : Bifunctorᴰ ,F-Bif (FUNCTORᴰ Cᴰ Cᴰ') (FUNCTORᴰ Cᴰ Dᴰ') (FUNCTORᴰ Cᴰ (Cᴰ' ×Cᴰ Dᴰ'))
+,Fᴰ-Bif .Bif-obᴰ = {!!}
+,Fᴰ-Bif .Bif-homLᴰ = {!!}
+,Fᴰ-Bif .Bif-homRᴰ = {!!}
+,Fᴰ-Bif .Bif-hom×ᴰ = {!!}
+,Fᴰ-Bif .Bif-×-idᴰ = {!!}
+,Fᴰ-Bif .Bif-×-seqᴰ = {!!}
+,Fᴰ-Bif .Bif-L×-agreeᴰ = {!!}
+,Fᴰ-Bif .Bif-R×-agreeᴰ = {!!}

--- a/Cubical/Categories/Displayed/Bifunctor.agda
+++ b/Cubical/Categories/Displayed/Bifunctor.agda
@@ -1,0 +1,72 @@
+{-# OPTIONS --safe #-}
+module Cubical.Categories.Displayed.Bifunctor where
+
+open import Cubical.Foundations.Prelude hiding (Path)
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+open import Cubical.Categories.NaturalTransformation
+open import Cubical.Categories.Constructions.BinProduct hiding (Fst; Snd; Sym)
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Instances.Functors
+open import Cubical.Categories.Bifunctor.Redundant
+
+open import Cubical.Categories.Displayed.Base
+
+open import Cubical.Data.Sigma
+
+private
+  variable
+    ℓ ℓ' ℓC ℓC' ℓD ℓD' ℓE ℓE' : Level
+    ℓᴰ ℓᴰ' ℓCᴰ ℓCᴰ' ℓDᴰ ℓDᴰ' ℓEᴰ ℓEᴰ' : Level
+
+module _ {C : Category ℓC ℓC'}
+         {D : Category ℓD ℓD'}
+         {E : Category ℓE ℓE'} where
+  record Bifunctorᴰ (F : Bifunctor C D E)
+                    (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ')
+                    (Dᴰ : Categoryᴰ D ℓDᴰ ℓDᴰ')
+                    (Eᴰ : Categoryᴰ E ℓEᴰ ℓEᴰ')
+     : Type (ℓ-max ℓC (ℓ-max ℓC' (ℓ-max ℓD (ℓ-max ℓD' (ℓ-max ℓE (ℓ-max ℓE'
+            (ℓ-max ℓCᴰ (ℓ-max ℓCᴰ' (ℓ-max ℓDᴰ (ℓ-max ℓDᴰ'
+            (ℓ-max ℓEᴰ ℓEᴰ'))))))))))) where
+
+    private
+      module Cᴰ = Categoryᴰ Cᴰ
+      module Dᴰ = Categoryᴰ Dᴰ
+      module Eᴰ = Categoryᴰ Eᴰ
+      module F = Bifunctor F
+    field
+      Bif-obᴰ : ∀ {c d} → Cᴰ.ob[ c ] → Dᴰ.ob[ d ] → Eᴰ.ob[ F ⟅ c , d ⟆b ]
+      Bif-homLᴰ : ∀ {c c' cᴰ cᴰ'} {f : C [ c , c' ]} (fᴰ : Cᴰ [ f ][ cᴰ , cᴰ' ])
+        {d} (dᴰ : Dᴰ.ob[ d ])
+        → Eᴰ [ F ⟪ f ⟫l ][ Bif-obᴰ cᴰ dᴰ , Bif-obᴰ cᴰ' dᴰ ]
+      Bif-homRᴰ : ∀ {c} (cᴰ : Cᴰ.ob[ c ]) {d d' dᴰ dᴰ'}
+        {g : D [ d , d' ]} (gᴰ : Dᴰ [ g ][ dᴰ , dᴰ' ])
+        → Eᴰ [ F ⟪ g ⟫r ][ Bif-obᴰ cᴰ dᴰ , Bif-obᴰ cᴰ dᴰ' ]
+      Bif-hom×ᴰ : ∀ {c c' d d'} {f : C [ c , c' ]}{g : D [ d , d' ]}
+             {cᴰ cᴰ' dᴰ dᴰ'}
+             (fᴰ : Cᴰ [ f ][ cᴰ , cᴰ' ])
+             (gᴰ : Dᴰ [ g ][ dᴰ , dᴰ' ])
+             → Eᴰ [ F ⟪ f , g ⟫× ][ Bif-obᴰ cᴰ dᴰ , Bif-obᴰ cᴰ' dᴰ' ]
+      Bif-×-idᴰ : ∀ {c d cᴰ dᴰ}
+        → Bif-hom×ᴰ (Cᴰ.idᴰ {p = cᴰ}) (Dᴰ.idᴰ {p = dᴰ})
+            Eᴰ.≡[ F.Bif-×-id {c = c}{d = d} ]
+          Eᴰ.idᴰ
+      Bif-×-seqᴰ :
+        ∀ {c c' c'' d d' d''}{cᴰ cᴰ' cᴰ'' dᴰ dᴰ' dᴰ''}
+        → {f : C [ c , c' ]}{f' : C [ c' , c'' ]}
+        → {g : D [ d , d' ]}{g' : D [ d' , d'' ]}
+        → (fᴰ : Cᴰ [ f ][ cᴰ , cᴰ' ]) (fᴰ' : Cᴰ [ f' ][ cᴰ' , cᴰ'' ])
+        → (gᴰ : Dᴰ [ g ][ dᴰ , dᴰ' ]) (gᴰ' : Dᴰ [ g' ][ dᴰ' , dᴰ'' ])
+        → Bif-hom×ᴰ (fᴰ Cᴰ.⋆ᴰ fᴰ') (gᴰ Dᴰ.⋆ᴰ gᴰ')
+            Eᴰ.≡[ F.Bif-×-seq f f' g g' ]
+          (Bif-hom×ᴰ fᴰ gᴰ Eᴰ.⋆ᴰ Bif-hom×ᴰ fᴰ' gᴰ')
+      Bif-L×-agreeᴰ : ∀ {c c' d}{cᴰ cᴰ' dᴰ}
+        {f : C [ c , c' ]}
+        (fᴰ : Cᴰ [ f ][ cᴰ , cᴰ' ])
+        → Bif-homLᴰ fᴰ dᴰ Eᴰ.≡[ F.Bif-L×-agree {d = d} f ] Bif-hom×ᴰ fᴰ Dᴰ.idᴰ
+      Bif-R×-agreeᴰ : ∀ {c d d'}{cᴰ dᴰ dᴰ'}
+        {g : D [ d , d' ]}
+        (gᴰ : Dᴰ [ g ][ dᴰ , dᴰ' ])
+        → Bif-homRᴰ cᴰ gᴰ Eᴰ.≡[ F.Bif-R×-agree {c = c} g ] Bif-hom×ᴰ Cᴰ.idᴰ gᴰ

--- a/Cubical/Categories/Displayed/Constructions/BinProduct/More.agda
+++ b/Cubical/Categories/Displayed/Constructions/BinProduct/More.agda
@@ -5,18 +5,22 @@
     weakening. Should it?
 
 -}
-{-# OPTIONS --safe #-}
+{-# OPTIONS --safe --lossy-unification #-}
 module Cubical.Categories.Displayed.Constructions.BinProduct.More where
 
 open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
 open import Cubical.Foundations.HLevels
 open import Cubical.Data.Sigma
 open import Cubical.Categories.Category.Base
 open import Cubical.Categories.Functor.Base
+open import Cubical.Categories.NaturalTransformation
+
 open import Cubical.Categories.Constructions.BinProduct
 open import Cubical.Categories.Constructions.BinProduct.More
 open import Cubical.Categories.Displayed.Base
 open import Cubical.Categories.Displayed.Functor
+open import Cubical.Categories.Displayed.NaturalTransformation
 open import Cubical.Categories.Displayed.Section.Base
 open import Cubical.Categories.Displayed.BinProduct
 open import Cubical.Categories.Constructions.TotalCategory
@@ -25,6 +29,7 @@ open import Cubical.Categories.Displayed.Constructions.TotalCategory
   as TotalCatᴰ hiding (introS; introF)
 open import Cubical.Categories.Displayed.Instances.Terminal as Unitᴰ
   hiding (introF)
+open import Cubical.Categories.Displayed.Instances.Functor
 open import Cubical.Categories.Displayed.Reasoning as Reasoning
 private
   variable
@@ -141,3 +146,31 @@ private
     introS' = compFunctorᴰGlobalSection
       (introF F (Unitᴰ.recᴰ Fᴰ₀) (Unitᴰ.recᴰ Fᴰ₁))
       ttS
+
+private
+  variable
+    ℓ ℓ' ℓC'' ℓC''' : Level
+    C C' D D'  : Category ℓ ℓ'
+    Cᴰ Cᴰ' Dᴰ'  : Categoryᴰ C ℓ ℓ'
+open Functorᴰ
+
+module _ {F : Functor C C'} {G : Functor C D'} where
+  _,Fᴰ_ : (Fᴰ : Functorᴰ F Cᴰ Cᴰ') → (Gᴰ : Functorᴰ G Cᴰ Dᴰ')
+    → Functorᴰ (F ,F G) Cᴰ (Cᴰ' ×Cᴰ Dᴰ')
+  (Fᴰ ,Fᴰ Gᴰ) .F-obᴰ x = F-obᴰ Fᴰ x , F-obᴰ Gᴰ x
+  (Fᴰ ,Fᴰ Gᴰ) .F-homᴰ x = F-homᴰ Fᴰ x , F-homᴰ Gᴰ x
+  (Fᴰ ,Fᴰ Gᴰ) .F-idᴰ = ΣPathP ((Fᴰ .F-idᴰ) , (Gᴰ .F-idᴰ))
+  (Fᴰ ,Fᴰ Gᴰ) .F-seqᴰ fᴰ gᴰ = ΣPathP ((Fᴰ .F-seqᴰ _ _) , Gᴰ .F-seqᴰ _ _)
+
+open NatTrans
+open NatTransᴰ
+,Fᴰ-functorᴰ :
+  Functorᴰ ,F-functor
+    ((FUNCTORᴰ Cᴰ Cᴰ') ×Cᴰ (FUNCTORᴰ Cᴰ Dᴰ'))
+    (FUNCTORᴰ Cᴰ (Cᴰ' ×Cᴰ Dᴰ'))
+,Fᴰ-functorᴰ .F-obᴰ (Fᴰ , Gᴰ) = Fᴰ ,Fᴰ Gᴰ
+,Fᴰ-functorᴰ .F-homᴰ (αᴰ , βᴰ) .N-obᴰ xᴰ = αᴰ .N-obᴰ xᴰ , βᴰ .N-obᴰ xᴰ
+,Fᴰ-functorᴰ .F-homᴰ (αᴰ , βᴰ) .N-homᴰ fᴰ =
+  ΣPathP (αᴰ .N-homᴰ fᴰ , βᴰ .N-homᴰ fᴰ)
+,Fᴰ-functorᴰ .F-idᴰ = makeNatTransPathᴰ _ _ _ refl
+,Fᴰ-functorᴰ .F-seqᴰ fᴰ gᴰ = makeNatTransPathᴰ _ _ _ refl

--- a/Cubical/Categories/Displayed/Exponentials.agda
+++ b/Cubical/Categories/Displayed/Exponentials.agda
@@ -1,0 +1,27 @@
+{-# OPTIONS --safe --lossy-unification #-}
+{-
+  Displayed Exponentials and, eventually, Vertical Exponentials
+-}
+module Cubical.Categories.Displayed.Exponentials where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Categories.Category
+open import Cubical.Categories.Exponentials
+open import Cubical.Categories.Limits.BinProduct.More
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Adjoint.More
+open import Cubical.Categories.Displayed.Limits.BinProduct
+
+private
+  variable
+    ℓC ℓC' ℓCᴰ ℓCᴰ' : Level
+
+module _ {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ') where
+  private
+    module Cᴰ = Categoryᴰ Cᴰ
+  Exponentialᴰ :
+    ∀ {c d} {c×- : hasAllBinProductWith C c}
+    cᴰ (dᴰ : Cᴰ.ob[ d ]) (cᴰ×ᴰ- : hasAllBinProductWithᴰ Cᴰ c×- cᴰ)
+    → (c⇒d : Exponential' C c d c×-)
+    → Type _
+  Exponentialᴰ cᴰ dᴰ cᴰ×ᴰ- c⇒d = RightAdjointAtᴰ (a×-Fᴰ Cᴰ cᴰ×ᴰ-) c⇒d dᴰ

--- a/Cubical/Categories/Displayed/FunctorComprehension.agda
+++ b/Cubical/Categories/Displayed/FunctorComprehension.agda
@@ -12,6 +12,7 @@ open import Cubical.Foundations.Function
 open import Cubical.Categories.Category
 open import Cubical.Categories.Functor
 open import Cubical.Categories.Profunctor.General
+open import Cubical.Categories.Presheaf.More
 open import Cubical.Categories.FunctorComprehension
 
 import Cubical.Categories.Constructions.TotalCategory as TotalCat

--- a/Cubical/Categories/Displayed/FunctorComprehension.agda
+++ b/Cubical/Categories/Displayed/FunctorComprehension.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --safe --lossy-unification #-}
+{-# OPTIONS --safe  --lossy-unification #-}
 {--
  -- Displayed Functor Comprehension
  -- Construction of a Displayed Functor by defining displayed universal elements
@@ -7,32 +7,17 @@ module Cubical.Categories.Displayed.FunctorComprehension where
 
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.HLevels
-open import Cubical.Foundations.Isomorphism
-open import Cubical.Foundations.Equiv
-open import Cubical.Foundations.Structure
-open import Cubical.Foundations.Univalence
-open import Cubical.Foundations.Function renaming (_∘_ to _∘f_)
+open import Cubical.Foundations.Function
 
-open import Cubical.Categories.Category renaming (isIso to isIsoC)
+open import Cubical.Categories.Category
 open import Cubical.Categories.Functor
-open import Cubical.Categories.Instances.Functors
-open import Cubical.Categories.Instances.Sets
-open import Cubical.Categories.Instances.Sets.More
 open import Cubical.Categories.Profunctor.General
-open import Cubical.Categories.Profunctor.FunctorComprehension
-open import Cubical.Data.Sigma
+open import Cubical.Categories.FunctorComprehension
 
-open import Cubical.Categories.Presheaf.Base
-
-open import Cubical.Categories.Presheaf.Representable
-open import Cubical.Categories.Instances.Functors.More
 import Cubical.Categories.Constructions.TotalCategory as TotalCat
 
 open import Cubical.Categories.Displayed.Base
 open import Cubical.Categories.Displayed.Functor
-open import Cubical.Categories.Displayed.Presheaf
-open import Cubical.Categories.Displayed.Instances.Sets.Base
-open import Cubical.Categories.Displayed.Instances.Functor
 open import Cubical.Categories.Displayed.Profunctor
 import Cubical.Categories.Displayed.Reasoning as Reasoning
 

--- a/Cubical/Categories/Displayed/Instances/Functor/Base.agda
+++ b/Cubical/Categories/Displayed/Instances/Functor/Base.agda
@@ -2,6 +2,7 @@
 module Cubical.Categories.Displayed.Instances.Functor.Base where
 
 open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
 open import Cubical.Foundations.HLevels
 import Cubical.Data.Equality as Eq
 
@@ -147,6 +148,7 @@ module _ {C : Category ℓC ℓC'}{D : Category ℓD ℓD'}
   FUNCTORᴰ .isSetHomᴰ {x = F} {y = G} {f = α} {xᴰ = Fᴰ} {yᴰ = Gᴰ} =
     isSetNatTransᴰ
 
+{- TODO: precompose/postcompose/compose are really just the three operations of a compose bifunctor -}
 module _
   {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} (E : Category ℓE ℓE')
   {F : Functor C D}
@@ -155,12 +157,24 @@ module _
   where
   open Functorᴰ
   open NatTransᴰ
+  import Cubical.Categories.Displayed.Reasoning Dᴰ as R
   precomposeFᴰ : Functorᴰ (precomposeF E F) (FUNCTORᴰ Dᴰ Eᴰ) (FUNCTORᴰ Cᴰ Eᴰ)
   precomposeFᴰ .F-obᴰ Gᴰ = Gᴰ ∘Fᴰ Fᴰ
   precomposeFᴰ .F-homᴰ αᴰ .N-obᴰ xᴰ = αᴰ .N-obᴰ (Fᴰ .F-obᴰ xᴰ)
   precomposeFᴰ .F-homᴰ αᴰ .N-homᴰ fᴰ = αᴰ .N-homᴰ (Fᴰ .F-homᴰ fᴰ)
   precomposeFᴰ .F-idᴰ = refl
   precomposeFᴰ .F-seqᴰ fᴰ gᴰ = refl
+
+  postcomposeFᴰ : Functorᴰ (postcomposeF E F) (FUNCTORᴰ Eᴰ Cᴰ) (FUNCTORᴰ Eᴰ Dᴰ)
+  postcomposeFᴰ .F-obᴰ Gᴰ = Fᴰ ∘Fᴰ Gᴰ
+  postcomposeFᴰ .F-homᴰ αᴰ .N-obᴰ xᴰ = F-homᴰ Fᴰ (αᴰ .N-obᴰ xᴰ)
+  postcomposeFᴰ .F-homᴰ αᴰ .N-homᴰ fᴰ = R.rectify $ R.≡out $
+    (sym $ R.≡in $ Fᴰ .F-seqᴰ _ _)
+    ∙ (R.≡in $ (λ i → Fᴰ .F-homᴰ (αᴰ .N-homᴰ fᴰ i)))
+    ∙ (R.≡in $ Fᴰ .F-seqᴰ _ _)
+  postcomposeFᴰ .F-idᴰ = makeNatTransPathᴰ _ _ _ λ i _ → Fᴰ .F-idᴰ i
+  postcomposeFᴰ .F-seqᴰ fᴰ gᴰ = makeNatTransPathᴰ _ _ _ λ i _ →
+    Fᴰ .F-seqᴰ (fᴰ .N-obᴰ _) (gᴰ .N-obᴰ _) i
 
 module _
   {C : Category ℓC ℓC'} (E : Category ℓE ℓE')

--- a/Cubical/Categories/Displayed/Instances/Functor/Base.agda
+++ b/Cubical/Categories/Displayed/Instances/Functor/Base.agda
@@ -148,7 +148,8 @@ module _ {C : Category ℓC ℓC'}{D : Category ℓD ℓD'}
   FUNCTORᴰ .isSetHomᴰ {x = F} {y = G} {f = α} {xᴰ = Fᴰ} {yᴰ = Gᴰ} =
     isSetNatTransᴰ
 
-{- TODO: precompose/postcompose/compose are really just the three operations of a compose bifunctor -}
+-- TODO: precompose/postcompose/compose are really just the three
+-- operations of a compose bifunctor
 module _
   {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} (E : Category ℓE ℓE')
   {F : Functor C D}

--- a/Cubical/Categories/Displayed/Instances/Sets/Base.agda
+++ b/Cubical/Categories/Displayed/Instances/Sets/Base.agda
@@ -13,7 +13,9 @@ open import Cubical.Categories.Functor
 open import Cubical.Categories.Constructions.TotalCategory
 open import Cubical.Categories.Yoneda
 open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Instances.Sets.More
 open import Cubical.Categories.Displayed.Instances.Functor
+open import Cubical.Categories.Displayed.BinProduct
 open import Cubical.Categories.Displayed.Base
 open import Cubical.Categories.Displayed.Functor
 open import Cubical.Categories.Displayed.NaturalTransformation
@@ -78,3 +80,13 @@ open Functor
 ΣF .F-hom (f , g) (x , y) = (f x) , (g x y)
 ΣF .F-id = refl
 ΣF .F-seq f g = refl
+
+×Setsᴰ : Functorᴰ ×Sets
+  (SETᴰ ℓ ℓ' ×Cᴰ SETᴰ ℓ'' ℓ''')
+  (SETᴰ (ℓ-max ℓ ℓ'') (ℓ-max ℓ' ℓ'''))
+×Setsᴰ .F-obᴰ (B₁ , B₂) (a₁ , a₂) =
+  (⟨ B₁ a₁ ⟩ × ⟨ B₂ a₂ ⟩)
+  , (isSet× (B₁ a₁ .snd) (B₂ a₂ .snd))
+×Setsᴰ .F-homᴰ (g₁ , g₂) (a₁ , a₂) (b₁ , b₂) = g₁ a₁ b₁ , g₂ a₂ b₂
+×Setsᴰ .F-idᴰ = refl
+×Setsᴰ .F-seqᴰ fᴰ gᴰ = refl

--- a/Cubical/Categories/Displayed/Limits/BinProduct/Base.agda
+++ b/Cubical/Categories/Displayed/Limits/BinProduct/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --safe #-}
+{-# OPTIONS --safe  --lossy-unification #-}
 module Cubical.Categories.Displayed.Limits.BinProduct.Base where
 
 open import Cubical.Foundations.Prelude
@@ -15,12 +15,15 @@ open import Cubical.Categories.Limits.BinProduct.More
 open import Cubical.Categories.Presheaf.Representable
 
 open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Bifunctor
 open import Cubical.Categories.Displayed.Functor
 open import Cubical.Categories.Displayed.FunctorComprehension
 open import Cubical.Categories.Displayed.Adjoint.More
 open import Cubical.Categories.Displayed.Constructions.BinProduct.More
 open import Cubical.Categories.Displayed.Presheaf
+open import Cubical.Categories.Displayed.Presheaf.Constructions
 open import Cubical.Categories.Displayed.Profunctor
+open import Cubical.Categories.Displayed.Instances.Sets.Base
 import Cubical.Categories.Displayed.Reasoning as HomᴰReasoning
 
 private
@@ -46,6 +49,20 @@ module _ {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓD ℓD') where
 
   hasAllBinProductᴰ : BinProducts' C → Type _
   hasAllBinProductᴰ = RightAdjointᴰ (ΔCᴰ Cᴰ)
+
+  open Functorᴰ
+  ProdWithAProfᴰ : ∀ {c} → Cᴰ.ob[ c ]
+    → Profunctorᴰ (ProdWithAProf C c) Cᴰ Cᴰ ℓD'
+  ProdWithAProfᴰ cᴰ = appLᴰ PshProdᴰ (YOᴰ .F-obᴰ cᴰ) ∘Fᴰ YOᴰ
+
+  hasAllBinProductWithᴰ : ∀ {c} → hasAllBinProductWith C c → Cᴰ.ob[ c ]
+    → Type (ℓ-max (ℓ-max (ℓ-max ℓC ℓC') ℓD) ℓD')
+  hasAllBinProductWithᴰ c×- cᴰ = UniversalElementsᴰ c×- (ProdWithAProfᴰ cᴰ)
+
+  a×-Fᴰ : ∀ {c}  {c×- : hasAllBinProductWith C c}
+            {cᴰ} (cᴰ×ᴰ- : hasAllBinProductWithᴰ c×- cᴰ)
+          → Functorᴰ (a×-F C c×-) Cᴰ Cᴰ
+  a×-Fᴰ {cᴰ = cᴰ} cᴰ×ᴰ- = FunctorᴰComprehension {Pᴰ = ProdWithAProfᴰ cᴰ} cᴰ×ᴰ-
 
   BinProductⱽ : ∀ {c} → (Cᴰ.ob[ c ] × Cᴰ.ob[ c ]) → Type _
   BinProductⱽ = VerticalRightAdjointAtᴰ (Δᴰ Cᴰ)
@@ -154,4 +171,3 @@ module _ {C  : Category ℓC ℓC'}{c : C .ob}{Cᴰ : Categoryᴰ C ℓCᴰ ℓC
       ×ηⱽ : {fᴰ : Cᴰ.Hom[ f ][ xᴰ , vert ]}
         → fᴰ ≡ (seqᴰⱽ Cᴰ fᴰ π₁ ,ⱽ seqᴰⱽ Cᴰ fᴰ π₂)
       ×ηⱽ = vbp.ηⱽ
-

--- a/Cubical/Categories/Displayed/Limits/BinProduct/Base.agda
+++ b/Cubical/Categories/Displayed/Limits/BinProduct/Base.agda
@@ -96,19 +96,23 @@ module hasAllBinProductᴰNotation
       open isIsoOver
       private
         ,pᴰ-isUniversalᴰ = bpᴰ (d₁ , d₂) .universalᴰ {xᴰ = d}
-      ×β₁ᴰ : ((f₁ᴰ ,pᴰ f₂ᴰ) Cᴰ.⋆ᴰ π₁ᴰ) Cᴰ.≡[ ×β₁ ] f₁ᴰ
-      ×β₁ᴰ i = UniversalElementᴰNotation.βᴰ _ _
-        (bpᴰ (d₁ , d₂)) {pᴰ = (f₁ᴰ , f₂ᴰ)} i .fst
+      opaque
+        unfolding UniversalElementᴰNotation.βᴰ
+        ×β₁ᴰ : ((f₁ᴰ ,pᴰ f₂ᴰ) Cᴰ.⋆ᴰ π₁ᴰ) Cᴰ.≡[ ×β₁ ] f₁ᴰ
+        ×β₁ᴰ = λ i → UniversalElementᴰNotation.βᴰ _ _
+          (bpᴰ (d₁ , d₂)) {pᴰ = (f₁ᴰ , f₂ᴰ)} i .fst
 
-      ×β₂ᴰ : ((f₁ᴰ ,pᴰ f₂ᴰ) Cᴰ.⋆ᴰ π₂ᴰ) Cᴰ.≡[ ×β₂ ] f₂ᴰ
-      ×β₂ᴰ i = UniversalElementᴰNotation.βᴰ _ _
-        (bpᴰ (d₁ , d₂)) {pᴰ = (f₁ᴰ , f₂ᴰ)} i .snd
+        ×β₂ᴰ : ((f₁ᴰ ,pᴰ f₂ᴰ) Cᴰ.⋆ᴰ π₂ᴰ) Cᴰ.≡[ ×β₂ ] f₂ᴰ
+        ×β₂ᴰ = λ i → UniversalElementᴰNotation.βᴰ _ _
+          (bpᴰ (d₁ , d₂)) {pᴰ = (f₁ᴰ , f₂ᴰ)} i .snd
 
     module _ {f : C [ c , c₁ BP.× c₂ ]}
              {fᴰ : Cᴰ.Hom[ f ][ d , d₁ ×ᴰ d₂ ]}
            where
-      ×ηᴰ : fᴰ Cᴰ.≡[ ×η ] ((fᴰ Cᴰ.⋆ᴰ π₁ᴰ) ,pᴰ (fᴰ Cᴰ.⋆ᴰ π₂ᴰ))
-      ×ηᴰ = UniversalElementᴰNotation.ηᴰ _ _ (bpᴰ (d₁ , d₂))
+      opaque
+        unfolding UniversalElementᴰNotation.ηᴰ
+        ×ηᴰ : fᴰ Cᴰ.≡[ ×η ] ((fᴰ Cᴰ.⋆ᴰ π₁ᴰ) ,pᴰ (fᴰ Cᴰ.⋆ᴰ π₂ᴰ))
+        ×ηᴰ = UniversalElementᴰNotation.ηᴰ _ _ (bpᴰ (d₁ , d₂))
 
 module _ {C  : Category ℓC ℓC'}{c : C .ob}{Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'} where
   private

--- a/Cubical/Categories/Displayed/Limits/Terminal.agda
+++ b/Cubical/Categories/Displayed/Limits/Terminal.agda
@@ -69,7 +69,7 @@ module _ {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ') where
     !tᴰ {c} d = introᴰ tt tt
 
     𝟙ηᴰ : ∀ {c} {d : Cᴰ.ob[ c ]} {f} (fᴰ : Cᴰ.Hom[ f ][ d , 𝟙ᴰ ])
-        → fᴰ Cᴰ.≡[ 𝟙η f ] !tᴰ d
+        → fᴰ Cᴰ.≡[ η ] !tᴰ d
     𝟙ηᴰ {c} {d} {f} fᴰ = ηᴰ
 
   module _ (c : C .ob) where

--- a/Cubical/Categories/Displayed/Presheaf.agda
+++ b/Cubical/Categories/Displayed/Presheaf.agda
@@ -36,6 +36,8 @@ open Functorᴰ
 
 -- equivalent to the data of a presheaf Pᴰ over ∫ D and a natural transformation
 -- Pᴰ → P ∘ Fst
+--
+-- IMO the order of D and P here should be swapped to match Functorᴰ
 Presheafᴰ : {C : Category ℓC ℓC'} (D : Categoryᴰ C ℓD ℓD')
           → (P : Presheaf C ℓP) → (ℓPᴰ : Level)
           → Type (ℓ-max (ℓ-max (ℓ-max (ℓ-max (ℓ-max ℓC ℓC') ℓD) ℓD') (ℓ-suc ℓP))
@@ -46,27 +48,61 @@ PRESHEAFᴰ : {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ')
   → ∀ (ℓP ℓPᴰ : Level) → Categoryᴰ (PresheafCategory C ℓP) _ _
 PRESHEAFᴰ Cᴰ ℓP ℓPᴰ = FUNCTORᴰ (Cᴰ ^opᴰ) (SETᴰ ℓP ℓPᴰ)
 
--- TODO: make a PresheafNotation to match
+∫P : {C : Category ℓC ℓC'} {D : Categoryᴰ C ℓD ℓD'}
+     → {P : Presheaf C ℓP} → {ℓPᴰ : Level} → Presheafᴰ D P ℓPᴰ
+     → Presheaf (TotalCat.∫C D) (ℓ-max ℓP ℓPᴰ)
+∫P Pᴰ = ΣF ∘F TotalCat.∫F Pᴰ
+
 module PresheafᴰNotation {C : Category ℓC ℓC'} {Cᴰ : Categoryᴰ C ℓD ℓD'}
          {P : Presheaf C ℓP} (Pᴰ : Presheafᴰ Cᴰ P ℓPᴰ) where
   private
     module C = Category C
     module Cᴰ = Categoryᴰ Cᴰ
+    module P = PresheafNotation P
 
   pob[_] : C .ob → Type ℓP
   pob[ x ] = ⟨ P ⟅ x ⟆ ⟩
 
-  p[_][_] : ∀ {x} → ⟨ P ⟅ x ⟆ ⟩ → Cᴰ.ob[ x ] → Type ℓPᴰ
+  p[_][_] : ∀ {x} → P.p[ x ] → Cᴰ.ob[ x ] → Type ℓPᴰ
   p[ f ][ xᴰ ] = ⟨ Pᴰ .F-obᴰ xᴰ f ⟩
 
-  _≡[_]_ : ∀ {x xᴰ} {f g : ⟨ P ⟅ x ⟆ ⟩} → p[ f ][ xᴰ ] → f ≡ g → p[ g ][ xᴰ ]
+  _⋆ᴰ_ : ∀ {x y xᴰ yᴰ}{f : C [ x , y ]}{g}
+     → Cᴰ [ f ][ xᴰ , yᴰ ] → p[ g ][ yᴰ ]
+     → p[ f P.⋆ g ][ xᴰ ]
+  fᴰ ⋆ᴰ gᴰ = Pᴰ .F-homᴰ fᴰ _ gᴰ
+
+  isSetPsh : ∀ {x} → isSet (P.p[ x ])
+  isSetPsh {x} = (P ⟅ x ⟆) .snd
+
+  _≡[_]_ : ∀ {x xᴰ} {f g : P.p[ x ]} → p[ f ][ xᴰ ] → f ≡ g → p[ g ][ xᴰ ]
     → Type ℓPᴰ
   _≡[_]_ {x} {xᴰ} {f} {g} fᴰ f≡g gᴰ = PathP (λ i → p[ f≡g i ][ xᴰ ]) fᴰ gᴰ
 
-  _⋆ᴰ_ : ∀ {x y xᴰ yᴰ}{f : C [ x , y ]}{g}
-    → Cᴰ [ f ][ xᴰ , yᴰ ] → p[ g ][ yᴰ ]
-    → p[ g ∘ᴾ⟨ C , P ⟩ f ][ xᴰ ]
-  fᴰ ⋆ᴰ gᴰ = Pᴰ .F-homᴰ fᴰ _ gᴰ
+  ≡in : {a : C.ob} {f g : P.p[ a ]}
+        {aᴰ : Cᴰ.ob[ a ]}
+        {fᴰ : p[ f ][ aᴰ ]}
+        {gᴰ : p[ g ][ aᴰ ]}
+        {p : f ≡ g}
+      → (fᴰ ≡[ p ] gᴰ)
+      → (f , fᴰ) ≡ (g , gᴰ)
+  ≡in e = ΣPathP (_ , e)
+
+  ≡out : {a : C.ob} {f g : P.p[ a ]}
+         {aᴰ : Cᴰ.ob[ a ]}
+         {fᴰ : p[ f ][ aᴰ ]}
+         {gᴰ : p[ g ][ aᴰ ]}
+       → (e : (f , fᴰ) ≡ (g , gᴰ))
+       → (fᴰ ≡[ fst (PathPΣ e) ] gᴰ)
+  ≡out e = snd (PathPΣ e)
+
+  rectify : {a : C.ob} {f g : P.p[ a ]} {p p' : f ≡ g}
+      {aᴰ : Cᴰ.ob[ a ]}
+      {fᴰ : p[ f ][ aᴰ ]}
+      {gᴰ : p[ g ][ aᴰ ]}
+    → fᴰ ≡[ p ] gᴰ → fᴰ ≡[ p' ] gᴰ
+  rectify {fᴰ = fᴰ} {gᴰ = gᴰ} = subst (fᴰ ≡[_] gᴰ) (isSetPsh _ _ _ _)
+
+  open PresheafNotation (∫P Pᴰ)
 
 module _ {C : Category ℓC ℓC'} (D : Categoryᴰ C ℓD ℓD')
          {P : Presheaf C ℓP} (Pᴰ : Presheafᴰ D P ℓPᴰ) where
@@ -93,7 +129,7 @@ module _ {C : Category ℓC ℓC'} (D : Categoryᴰ C ℓD ℓD')
     open UniversalElement
     open UniversalElementᴰ
     ∫UE : ∀ {ue : UniversalElement C P} (ueᴰ : UniversalElementᴰ ue)
-      → UniversalElement (TotalCat.∫C D) (ΣF ∘F TotalCat.∫F Pᴰ)
+      → UniversalElement (TotalCat.∫C D) (∫P Pᴰ)
     ∫UE {ue = ue} ueᴰ .vertex = ue .vertex , ueᴰ .vertexᴰ
     ∫UE {ue = ue} ueᴰ .element = ue .element , ueᴰ .elementᴰ
     ∫UE {ue = ue} ueᴰ .universal (v , vᴰ) =
@@ -106,33 +142,40 @@ module _ {C : Category ℓC ℓC'} (D : Categoryᴰ C ℓD ℓD')
     open UniversalElementNotation ue public
     open UniversalElementᴰ ueᴰ public
     private
+      module P = PresheafNotation P
       module ∫ue = UniversalElementNotation (∫UE ueᴰ)
 
     introᴰ : ∀ {x xᴰ} (p : ⟨ P ⟅ x ⟆ ⟩)
         → Pᴰ.p[ p ][ xᴰ ]
         → D [ intro p ][ xᴰ , vertexᴰ ]
     introᴰ p pᴰ = ∫ue.intro (p , pᴰ) .snd
+    opaque
+      unfolding β
+      βᴰ : ∀ {x xᴰ} {p : Pᴰ.pob[ x ] } {pᴰ : Pᴰ.p[ p ][ xᴰ ]}
+           → (introᴰ p pᴰ Pᴰ.⋆ᴰ elementᴰ) Pᴰ.≡[ β ] pᴰ
+      βᴰ = cong snd ∫ue.β
 
-    βᴰ : ∀ {x xᴰ} {p : Pᴰ.pob[ x ] } {pᴰ : Pᴰ.p[ p ][ xᴰ ]}
-         → (introᴰ p pᴰ Pᴰ.⋆ᴰ elementᴰ) Pᴰ.≡[ β ] pᴰ
-    βᴰ = cong snd ∫ue.β
+      ηᴰ : ∀ {x xᴰ} {f : C [ x , vertex ]} {fᴰ : D [ f ][ xᴰ , vertexᴰ ]}
+           → fᴰ D.≡[ η {f = f} ] (introᴰ _ (fᴰ Pᴰ.⋆ᴰ elementᴰ))
+      ηᴰ = R.rectify $ cong snd ∫ue.η
 
-    ηᴰ : ∀ {x xᴰ} {f : C [ x , vertex ]} {fᴰ : D [ f ][ xᴰ , vertexᴰ ]}
-         → fᴰ D.≡[ η {f = f} ] (introᴰ _ (F-homᴰ Pᴰ fᴰ element elementᴰ))
-    ηᴰ = R.rectify $ cong snd ∫ue.η
+      weak-ηᴰ : D.idᴰ D.≡[ weak-η ] introᴰ _ elementᴰ
+      weak-ηᴰ = R.rectify $ cong snd ∫ue.weak-η
 
-    weak-ηᴰ : D.idᴰ D.≡[ weak-η ] introᴰ _ elementᴰ
-    weak-ηᴰ = R.rectify $ cong snd ∫ue.weak-η
+      extensionalityᴰ
+        : ∀ {x xᴰ} {f g : C [ x , vertex ]}
+          {fᴰ : D [ f ][ xᴰ , vertexᴰ ]}
+          {gᴰ : D [ g ][ xᴰ , vertexᴰ ]}
+        → (fπ≡gπ : f P.⋆ element  ≡ g P.⋆ element)
+        → (fᴰ Pᴰ.⋆ᴰ elementᴰ) Pᴰ.≡[ fπ≡gπ ] (gᴰ Pᴰ.⋆ᴰ elementᴰ)
+        → fᴰ D.≡[ extensionality fπ≡gπ ] gᴰ
+      extensionalityᴰ fπ≡gπ p = R.rectify $
+        cong snd (∫ue.extensionality (ΣPathP (fπ≡gπ , p)))
 
-    extensionalityᴰ
-      : ∀ {x xᴰ} {f g : C [ x , vertex ]}
-        {fᴰ : D [ f ][ xᴰ , vertexᴰ ]}
-        {gᴰ : D [ g ][ xᴰ , vertexᴰ ]}
-      → (fπ≡gπ : element ∘ᴾ⟨ C , P ⟩ f ≡ element ∘ᴾ⟨ C , P ⟩ g)
-      → (fᴰ Pᴰ.⋆ᴰ elementᴰ) Pᴰ.≡[ fπ≡gπ ] (gᴰ Pᴰ.⋆ᴰ elementᴰ)
-      → fᴰ D.≡[ extensionality fπ≡gπ ] gᴰ
-    extensionalityᴰ fπ≡gπ p = R.rectify $
-      cong snd (∫ue.extensionality (ΣPathP (fπ≡gπ , p)))
+      introᴰ-natural : ∀ {x y}{f : C [ x , y ]}{p : P.p[ y ]}
+        {xᴰ yᴰ}{fᴰ : D [ f ][ xᴰ , yᴰ ]}{pᴰ : Pᴰ.p[ p ][ yᴰ ]}
+        → (fᴰ D.⋆ᴰ introᴰ _ pᴰ) D.≡[ intro-natural ] introᴰ _ (fᴰ Pᴰ.⋆ᴰ pᴰ)
+      introᴰ-natural = R.rectify $ cong snd (∫ue.intro-natural)
 
 -- A vertical presheaf is a displayed presheaf over a representable
 Presheafⱽ : {C : Category ℓC ℓC'} (D : Categoryᴰ C ℓD ℓD')

--- a/Cubical/Categories/Displayed/Presheaf/Constructions.agda
+++ b/Cubical/Categories/Displayed/Presheaf/Constructions.agda
@@ -1,0 +1,47 @@
+{-# OPTIONS --safe --lossy-unification #-}
+module Cubical.Categories.Displayed.Presheaf.Constructions where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Structure
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+open import Cubical.Categories.NaturalTransformation
+open import Cubical.Categories.Instances.Functors
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Constructions.BinProduct
+open import Cubical.Categories.Constructions.BinProduct.More
+open import Cubical.Categories.Instances.Sets.More
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Bifunctor.Redundant
+
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Bifunctor
+open import Cubical.Categories.Displayed.Functor
+open import Cubical.Categories.Displayed.Instances.Functor.Base
+open import Cubical.Categories.Displayed.Instances.Sets.Base
+open import Cubical.Categories.Displayed.BinProduct
+open import Cubical.Categories.Displayed.Constructions.BinProduct.More
+open import Cubical.Categories.Displayed.Presheaf
+open import Cubical.Categories.Presheaf.Constructions
+private
+  variable
+    ℓ ℓ' ℓᴰ ℓᴰ' : Level
+
+module _ {C : Category ℓ ℓ'} {Cᴰ : Categoryᴰ C ℓᴰ ℓᴰ'} {ℓA ℓB ℓAᴰ ℓBᴰ : Level}
+  where
+  private
+    𝓟 = PresheafCategory C ℓA
+    𝓟ᴰ = PRESHEAFᴰ Cᴰ ℓA ℓAᴰ
+    𝓠 = PresheafCategory C ℓB
+    𝓠ᴰ = PRESHEAFᴰ Cᴰ ℓB ℓBᴰ
+    𝓡 = PresheafCategory C (ℓ-max ℓA ℓB)
+    𝓡ᴰ = PRESHEAFᴰ Cᴰ (ℓ-max ℓA ℓB) (ℓ-max ℓAᴰ ℓBᴰ)
+
+  PshProd'ᴰ : Functorᴰ PshProd' (𝓟ᴰ ×Cᴰ 𝓠ᴰ) 𝓡ᴰ
+  PshProd'ᴰ = postcomposeFᴰ (C ^op) (Cᴰ ^opᴰ) ×Setsᴰ ∘Fᴰ ,Fᴰ-functorᴰ
+
+  PshProdᴰ : Bifunctorᴰ PshProd 𝓟ᴰ 𝓠ᴰ 𝓡ᴰ
+  PshProdᴰ = ParFunctorᴰToBifunctorᴰ PshProd'ᴰ

--- a/Cubical/Categories/Exponentials.agda
+++ b/Cubical/Categories/Exponentials.agda
@@ -30,6 +30,9 @@ module _ (C : Category ℓC ℓC') where
   Exponential : (c d : C .ob) → (∀ (e : C .ob) → BinProduct C c e) → Type _
   Exponential c d c×- = RightAdjointAt (BinProductWithF _ c×-) d
 
+  Exponential' : (c d : C .ob) → (c×- : hasAllBinProductWith C c) → Type _
+  Exponential' c d c×- = RightAdjointAt (a×-F C c×-) d
+
   module ExponentialNotation {c d} c×- (exp : Exponential c d c×-) where
     open UniversalElementNotation exp public
     open ProdsWithNotation C c×- public

--- a/Cubical/Categories/Exponentials.agda
+++ b/Cubical/Categories/Exponentials.agda
@@ -15,6 +15,7 @@ open import Cubical.Categories.Profunctor.FunctorComprehension
 open import Cubical.Categories.Adjoint.UniversalElements
 open import Cubical.Categories.Adjoint.2Var
 open import Cubical.Categories.Presheaf.Representable
+open import Cubical.Categories.Presheaf.More
 open import Cubical.Categories.Limits.BinProduct
 open import Cubical.Categories.Limits.BinProduct.More
 
@@ -23,12 +24,32 @@ private
     ℓC ℓC' : Level
 
 open Category
-open UniversalElement
 open isEquiv
 
 module _ (C : Category ℓC ℓC') where
   Exponential : (c d : C .ob) → (∀ (e : C .ob) → BinProduct C c e) → Type _
   Exponential c d c×- = RightAdjointAt (BinProductWithF _ c×-) d
+
+  module ExponentialNotation {c d} c×- (exp : Exponential c d c×-) where
+    open UniversalElementNotation exp public
+    open ProdsWithNotation C c×- public
+    c⇒d : C .ob
+    c⇒d = vertex
+
+    app : C [ a× c⇒d , d ]
+    app = element
+
+    lda : ∀ {Γ} → C [ a× Γ , d ] → C [ Γ , c⇒d ]
+    lda = intro
+
+    -- this is to test we have the expected definition
+    β⇒ : ∀ {Γ} → (f : C [ a× Γ , d ])
+      → π₁ ,p (π₂ ⋆⟨ C ⟩ lda f) ⋆⟨ C ⟩ app ≡ f
+    β⇒ f = β {p = f}
+
+    η⇒ : ∀ {Γ} → (f : C [ Γ , c⇒d ])
+      → f ≡ lda ((π₁ ,p (π₂ ⋆⟨ C ⟩ f)) ⋆⟨ C ⟩ app)
+    η⇒ f = η {f = f}
 
   module _ (bp : BinProducts C) where
     open Notation C bp
@@ -38,8 +59,9 @@ module _ (C : Category ℓC ℓC') where
     ExponentialF : Exponentials → Functor ((C ^op) ×C C) C
     ExponentialF exps =
       FunctorComprehension {P = RightAdjointLProf ×Bif} exps ∘F Prod.Sym
+    open UniversalElement
 
-    module ExpNotation (exp : Exponentials) where
+    module ExpsNotation (exp : Exponentials) where
       _⇒_ : C .ob → C .ob → C .ob
       c ⇒ d = exp (d , c) .vertex
 

--- a/Cubical/Categories/FunctorComprehension.agda
+++ b/Cubical/Categories/FunctorComprehension.agda
@@ -1,0 +1,70 @@
+{-# OPTIONS --safe --lossy-unification #-}
+{--
+ -- Functor Comprehension
+ -- ======================
+ -- This module provides a method for constructing functors by showing
+ -- that they have a universal property.
+ --
+ -- The idea is that if you wish to define a functor F : C → D via a
+ -- universal property (P c), then the functoriality of F comes for
+ -- free if the universal property P is given functorially, that is if
+ -- P is a functor P : C → Psh D
+ --
+ -- That is, if you construct for each c a universal element of P c,
+ -- then this can be *uniquely* extended to a functorial action on
+ -- morphisms, and furthermore you get that the universal elements so
+ -- constructed are natural with respect to this functorial action.
+ -- We provide this data in this module in two equivalent forms:
+ -- 1. A "natural element" ∀ c → P c (F c)
+ -- 2. A natural isomorphism (Y ∘ F ≅ P)
+ --
+ -- The fact is essentially a corollary of the Yoneda lemma, but we
+ --
+ -- Constructing a functor in this method saves a lot of work in
+ -- repeatedly demonstrating functoriality
+ --
+ --}
+module Cubical.Categories.FunctorComprehension where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+open import Cubical.Categories.NaturalTransformation
+open import Cubical.Categories.Presheaf.Representable
+open import Cubical.Categories.Presheaf.More
+open import Cubical.Categories.Profunctor.General
+
+private
+  variable
+    ℓC ℓC' ℓD ℓD' ℓS ℓR : Level
+
+open Category
+open Functor
+open NatTrans
+open UniversalElement
+open UniversalElementNotation
+
+module _ {C : Category ℓC ℓC'}{D : Category ℓD ℓD'}
+         {P : Profunctor C D ℓS}
+         (ues : UniversalElements P)
+         where
+  private
+    module C = Category C
+  FunctorComprehension : Functor C D
+  FunctorComprehension .F-ob x = ues x .vertex
+  FunctorComprehension .F-hom {x}{y} f =
+    intro (ues y) ((P ⟪ f ⟫) .N-ob _ (ues x .element))
+  FunctorComprehension .F-id {x} =
+    (λ i → intro (ues x) (P .F-id i .N-ob _ (ues x .element)))
+    ∙ (sym $ weak-η (ues x))
+  FunctorComprehension .F-seq {x}{y}{z} f g =
+    ((λ i → intro (ues z) (P .F-seq f g i .N-ob _ (ues x .element))))
+    ∙ (cong (intro (ues z)) $
+      ((λ i → P .F-hom g .N-ob _
+        (β (ues y) {p = P .F-hom f .N-ob _ (ues x .element)} (~ i))))
+      ∙ funExt⁻ (P .F-hom g .N-hom _) _)
+    ∙ (sym $ intro-natural (ues z))

--- a/Cubical/Categories/Instances/Sets/More.agda
+++ b/Cubical/Categories/Instances/Sets/More.agda
@@ -24,18 +24,19 @@ private
     ℓ ℓ' : Level
 
 open Functor
-×SetsBif : Bifunctor (SET ℓ) (SET ℓ) (SET ℓ)
+×SetsBif : Bifunctor (SET ℓ) (SET ℓ') (SET (ℓ-max ℓ ℓ'))
 ×SetsBif = mkBifunctorParAx F where
   open BifunctorParAx
-  F : BifunctorParAx (SET ℓ) (SET ℓ) (SET ℓ)
-  F .Bif-ob A B = ⟨ A ⟩ × ⟨ B ⟩ , isSet× (A .snd) (B .snd)
-  F .Bif-homL f B (x , y) = f x , y
-  F .Bif-homR A g (x , y) = x , (g y)
-  F .Bif-hom× f g (x , y) = (f x) , (g y)
+  F : BifunctorParAx (SET _) (SET _) (SET _)
+  F .Bif-ob A B .fst = ⟨ A ⟩ × ⟨ B ⟩
+  F .Bif-ob A B .snd = isSet× (A .snd) (B .snd)
+  F .Bif-homL = λ f d z → f (z .fst) , z .snd
+  F .Bif-homR = λ c g z → z .fst , g (z .snd)
+  F .Bif-hom× = λ f g z → f (z .fst) , g (z .snd)
   F .Bif-×-id = refl
   F .Bif-×-seq f f' g g' = refl
   F .Bif-L×-agree f = refl
   F .Bif-R×-agree g = refl
 
-×Sets : Functor ((SET ℓ) ×C (SET ℓ)) (SET ℓ)
+×Sets : Functor (SET ℓ ×C SET ℓ') (SET (ℓ-max ℓ ℓ'))
 ×Sets = BifunctorToParFunctor ×SetsBif

--- a/Cubical/Categories/Limits/BinProduct/More.agda
+++ b/Cubical/Categories/Limits/BinProduct/More.agda
@@ -16,7 +16,7 @@ open import Cubical.Categories.NaturalTransformation
 open import Cubical.Categories.Functors.Constant
 open import Cubical.Categories.Functor
 open import Cubical.Categories.Profunctor.General
-open import Cubical.Categories.Profunctor.FunctorComprehension
+open import Cubical.Categories.FunctorComprehension
 open import Cubical.Categories.Isomorphism
 open import Cubical.Categories.Instances.Sets.More
 open import Cubical.Categories.Limits.BinProduct
@@ -65,6 +65,9 @@ module _ (C : Category ℓ ℓ') where
   -- Product with a fixed object
   ProdWithAProf : C .ob → Profunctor C C ℓ'
   ProdWithAProf a = appL PshProd (YO ⟅ a ⟆) ∘F YO
+
+  hasAllBinProductWith : C .ob → Type (ℓ-max ℓ ℓ')
+  hasAllBinProductWith a = UniversalElements (ProdWithAProf a)
 
   BinProductToRepresentable : ∀ {a b} → BinProduct C a b
     → UniversalElement C (BinProductProf ⟅ a , b ⟆)
@@ -128,6 +131,10 @@ module _ (C : Category ℓ ℓ') where
     variable
       a b c d : C .ob
       f g h : C [ a , b ]
+  module _ {a} (a×- : hasAllBinProductWith a) where
+    a×-F : Functor C C
+    a×-F = FunctorComprehension a×-
+
   module _ {a} (bp : ∀ b → BinProduct C a b) where
     BinProductWithToRepresentable : UniversalElements (ProdWithAProf a)
     BinProductWithToRepresentable b = BinProductToRepresentable (bp b)

--- a/Cubical/Categories/Limits/BinProduct/More.agda
+++ b/Cubical/Categories/Limits/BinProduct/More.agda
@@ -53,8 +53,14 @@ module _ (C : Category ℓ ℓ') where
     BadBinProductProf =
       (precomposeF _ (Δ C ^opF) ∘F YO) ∘F R.RedundantToProd C C
 
+    -- This definition is *almost* exactly the same as the next one,
+    -- except using ∘F YO ×F YO vs ∘Flr YO , YO. But it has the same
+    -- problem as the previous. That ∘F vs ∘Flr makes all the difference.
+    AlsoBadBinProductProf : Profunctor (C ⊗ C) C ℓ'
+    AlsoBadBinProductProf = R.rec C C (ParFunctorToBifunctor (PshProd' ∘F (YO ×F YO)))
+
   BinProductProf : Profunctor (C ⊗ C) C ℓ'
-  BinProductProf = R.rec _ _ (PshProd ∘Flr (YO , YO))
+  BinProductProf = R.rec C C (PshProd ∘Flr (YO , YO))
 
   -- Product with a fixed object
   ProdWithAProf : C .ob → Profunctor C C ℓ'

--- a/Cubical/Categories/Limits/BinProduct/More.agda
+++ b/Cubical/Categories/Limits/BinProduct/More.agda
@@ -57,7 +57,8 @@ module _ (C : Category ℓ ℓ') where
     -- except using ∘F YO ×F YO vs ∘Flr YO , YO. But it has the same
     -- problem as the previous. That ∘F vs ∘Flr makes all the difference.
     AlsoBadBinProductProf : Profunctor (C ⊗ C) C ℓ'
-    AlsoBadBinProductProf = R.rec C C (ParFunctorToBifunctor (PshProd' ∘F (YO ×F YO)))
+    AlsoBadBinProductProf =
+      R.rec C C (ParFunctorToBifunctor (PshProd' ∘F (YO ×F YO)))
 
   BinProductProf : Profunctor (C ⊗ C) C ℓ'
   BinProductProf = R.rec C C (PshProd ∘Flr (YO , YO))

--- a/Cubical/Categories/Limits/BinProduct/More.agda
+++ b/Cubical/Categories/Limits/BinProduct/More.agda
@@ -131,9 +131,9 @@ module _ (C : Category ℓ ℓ') where
 
     -- test definitional behavior
     _ : ∀ {b b'}(f : C [ b , b' ]) →
-        BinProductWithF ⟪ f ⟫ ≡
-          bp b' .univProp (bp b .binProdPr₁)
-            (f ∘⟨ C ⟩ bp b .binProdPr₂) .fst .fst
+          BinProductWithF ⟪ f ⟫ ≡
+            bp b' .univProp (bp b .binProdPr₁)
+              (f ∘⟨ C ⟩ bp b .binProdPr₂) .fst .fst
     _ = λ f → refl
     module ProdsWithNotation where
       open UniversalElementNotation {C = C}

--- a/Cubical/Categories/Limits/BinProduct/More.agda
+++ b/Cubical/Categories/Limits/BinProduct/More.agda
@@ -58,7 +58,7 @@ module _ (C : Category ℓ ℓ') where
 
   -- Product with a fixed object
   ProdWithAProf : C .ob → Profunctor C C ℓ'
-  ProdWithAProf a = BinProductProf ∘F R.ob-× C C a
+  ProdWithAProf a = appL PshProd (YO ⟅ a ⟆) ∘F YO
 
   BinProductToRepresentable : ∀ {a b} → BinProduct C a b
     → UniversalElement C (BinProductProf ⟅ a , b ⟆)

--- a/Cubical/Categories/Presheaf/Constructions.agda
+++ b/Cubical/Categories/Presheaf/Constructions.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --safe #-}
+{-# OPTIONS --safe --lossy-unification #-}
 module Cubical.Categories.Presheaf.Constructions where
 
 open import Cubical.Foundations.Prelude
@@ -12,6 +12,7 @@ open import Cubical.Categories.NaturalTransformation
 open import Cubical.Categories.Instances.Functors
 open import Cubical.Categories.Instances.Sets
 open import Cubical.Categories.Constructions.BinProduct
+open import Cubical.Categories.Constructions.BinProduct.More
 open import Cubical.Categories.Instances.Sets.More
 open import Cubical.Categories.Presheaf.Base
 open import Cubical.Categories.Bifunctor.Redundant
@@ -26,8 +27,11 @@ module _ {C : Category ℓ ℓ'} {ℓA ℓB : Level} where
     𝓠 = PresheafCategory C ℓB
     𝓡 = PresheafCategory C (ℓ-max ℓA ℓB)
 
+  PshProd' : Functor (𝓟 ×C 𝓠) 𝓡
+  PshProd' = (postcomposeF _ ×Sets ∘F ,F-functor)
+
   PshProd : Bifunctor 𝓟 𝓠 𝓡
-  PshProd = postcomposeF _ ×Sets ∘Fb ,F-Bif
+  PshProd = ParFunctorToBifunctor PshProd'
 
   private
     open Category

--- a/Cubical/Categories/Presheaf/Constructions.agda
+++ b/Cubical/Categories/Presheaf/Constructions.agda
@@ -7,10 +7,12 @@ open import Cubical.Foundations.Structure
 open import Cubical.Data.Sigma
 
 open import Cubical.Categories.Category
-open import Cubical.Categories.Functor.Base
+open import Cubical.Categories.Functor
 open import Cubical.Categories.NaturalTransformation
 open import Cubical.Categories.Instances.Functors
 open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Constructions.BinProduct
+open import Cubical.Categories.Instances.Sets.More
 open import Cubical.Categories.Presheaf.Base
 open import Cubical.Categories.Bifunctor.Redundant
 
@@ -25,38 +27,7 @@ module _ {C : Category ℓ ℓ'} {ℓA ℓB : Level} where
     𝓡 = PresheafCategory C (ℓ-max ℓA ℓB)
 
   PshProd : Bifunctor 𝓟 𝓠 𝓡
-  PshProd = mkBifunctorPar B where
-    open BifunctorPar
-    open Functor
-    open NatTrans
-    open Category
-    Bob : 𝓟 .ob → 𝓠 .ob → 𝓡 .ob
-    Bob P Q .F-ob c =  ⟨ P ⟅ c ⟆ ⟩ × ⟨ Q ⟅ c ⟆ ⟩ ,
-      isSet× (str (P ⟅ c ⟆)) ((str (Q ⟅ c ⟆)))
-    Bob P Q .F-hom f (p , q) = (P .F-hom f p) , (Q .F-hom f q)
-    Bob P Q .F-id =
-      funExt (λ (p , q) → ΣPathP ((funExt⁻ (P .F-id) p) , funExt⁻ (Q .F-id) q))
-    Bob P Q .F-seq f g =
-      funExt λ (p , q) → ΣPathP
-        ( (funExt⁻ (P .F-seq f g) p)
-        , (funExt⁻ (Q .F-seq f g) q))
-
-    Bhom× :
-      ∀ {P P' Q Q'} →
-      𝓟 [ P , P' ] →
-      𝓠 [ Q , Q' ] →
-      𝓡 [ Bob P Q , Bob P' Q' ]
-    Bhom× α β .N-ob c (p , q) = α .N-ob c p , β .N-ob c q
-    Bhom× α β .N-hom f = funExt λ (p , q) →
-      ΣPathP (funExt⁻ (α .N-hom f) _ , funExt⁻ (β .N-hom f) _)
-
-    B : BifunctorPar 𝓟 𝓠 𝓡
-    B .Bif-ob = Bob
-    B .Bif-hom× = Bhom×
-    B .Bif-×-id =
-      makeNatTransPath (funExt (λ c → funExt (λ (p , q) → refl)))
-    B .Bif-×-seq α α' β β' =
-      makeNatTransPath (funExt (λ c → funExt (λ (p , q) → refl)))
+  PshProd = postcomposeF _ ×Sets ∘Fb ,F-Bif
 
   private
     open Category

--- a/Cubical/Categories/Presheaf/More.agda
+++ b/Cubical/Categories/Presheaf/More.agda
@@ -93,7 +93,7 @@ module PresheafNotation {ℓo}{ℓh}
   ⋆Assoc f g = funExt⁻ (P .F-seq g f)
 
   ⟨_⟩⋆⟨_⟩ : ∀ {x y} {f f' : C [ x , y ]} {g g' : p[ y ]}
-          → f ≡ f' → g ≡ g' → f ⋆ g ≡ f' ⋆ g'
+            → f ≡ f' → g ≡ g' → f ⋆ g ≡ f' ⋆ g'
   ⟨ f≡f' ⟩⋆⟨ g≡g' ⟩ = cong₂ _⋆_ f≡f' g≡g'
 
 module UniversalElementNotation {ℓo}{ℓh}
@@ -118,26 +118,31 @@ module UniversalElementNotation {ℓo}{ℓh}
   universalIso : ∀ (c : C .ob) → Iso (C [ c , vertex ]) ⟨ P ⟅ c ⟆ ⟩
   universalIso c = equivToIso (_ , universal c)
 
-  intro : ∀ {c} → ⟨ P ⟅ c ⟆ ⟩ → C [ c , vertex ]
+  private
+    module P = PresheafNotation P
+    module C = Category C
+
+  intro : ∀ {c} → P.p[ c ] → C [ c , vertex ]
   intro = universalIso _ .inv
 
-  β : ∀ {c} → {p : ⟨ P ⟅ c ⟆ ⟩} → (element ∘ᴾ⟨ C , P ⟩ intro p) ≡ p
-  β = universalIso _ .rightInv _
+  opaque
+    β : ∀ {c} → {p : P.p[ c ]} → (intro p P.⋆ element) ≡ p
+    β = universalIso _ .rightInv _
 
-  η : ∀ {c} → {f : C [ c , vertex ]} → f ≡ intro (element ∘ᴾ⟨ C , P ⟩ f)
-  η {f = f} = sym (universalIso _ .leftInv _)
+    η : ∀ {c} → {f : C [ c , vertex ]} → f ≡ intro (f P.⋆ element)
+    η {f = f} = sym (universalIso _ .leftInv _)
 
-  weak-η : C .id ≡ intro element
-  weak-η = η ∙ cong intro (∘ᴾId C P _)
+    weak-η : C .id ≡ intro element
+    weak-η = η ∙ cong intro (∘ᴾId C P _)
 
-  extensionality : ∀ {c} → {f f' : C [ c , vertex ]}
-                 → (element ∘ᴾ⟨ C , P ⟩ f) ≡ (element ∘ᴾ⟨ C , P ⟩ f')
-                 → f ≡ f'
-  extensionality = isoFunInjective (equivToIso (_ , (universal _))) _ _
+    extensionality : ∀ {c} → {f f' : C [ c , vertex ]}
+                   → (f P.⋆ element) ≡ (f' P.⋆ element)
+                   → f ≡ f'
+    extensionality = isoFunInjective (equivToIso (_ , (universal _))) _ _
 
-  intro-natural : ∀ {c' c} → {p : ⟨ P ⟅ c ⟆ ⟩}{f : C [ c' , c ]}
-                → intro p ∘⟨ C ⟩ f ≡ intro (p ∘ᴾ⟨ C , P ⟩ f)
-  intro-natural = extensionality
-    ( (∘ᴾAssoc C P _ _ _
-    ∙ cong (action C P _) β)
-    ∙ sym β)
+    intro-natural : ∀ {c' c} → {p : P.p[ c ]}{f : C [ c' , c ]}
+                  → f C.⋆ intro p ≡ intro (f P.⋆ p)
+    intro-natural = extensionality
+      ( (∘ᴾAssoc C P _ _ _
+      ∙ cong (action C P _) β)
+      ∙ sym β)

--- a/Cubical/Categories/Presheaf/More.agda
+++ b/Cubical/Categories/Presheaf/More.agda
@@ -21,7 +21,6 @@ open import Cubical.Categories.Presheaf.Representable
 open import Cubical.Categories.Instances.Sets.More
 open import Cubical.Categories.Isomorphism.More
 
-open Category
 open Functor
 
 private
@@ -45,7 +44,7 @@ IdPshIso C P = idCatIso
 𝓟* : Category ℓ ℓ' → (ℓS : Level) → Type (ℓ-max (ℓ-max ℓ ℓ') (ℓ-suc ℓS))
 𝓟* C ℓS = Functor C (SET ℓS)
 
-module _ (C : Category ℓ ℓ') (c : C .ob) where
+module _ (C : Category ℓ ℓ') (c : C .Category.ob) where
   open Category
   open UniversalElement
 
@@ -65,7 +64,7 @@ module _ (C : Category ℓ ℓ') (c : C .ob) where
 
 module _ {ℓo}{ℓh}{ℓp} (C : Category ℓo ℓh) (P : Presheaf C ℓp) where
   open UniversalElement
-
+  open Category
   UniversalElementOn : C .ob → Type (ℓ-max (ℓ-max ℓo ℓh) ℓp)
   UniversalElementOn vertex =
     Σ[ element ∈ (P ⟅ vertex ⟆) .fst ] isUniversal C P vertex element
@@ -75,10 +74,33 @@ module _ {ℓo}{ℓh}{ℓp} (C : Category ℓo ℓh) (P : Presheaf C ℓp) where
   UniversalElementToUniversalElementOn ue .fst = ue .element
   UniversalElementToUniversalElementOn ue .snd = ue .universal
 
+module PresheafNotation {ℓo}{ℓh}
+       {C : Category ℓo ℓh} {ℓp} (P : Presheaf C ℓp)
+       where
+  private
+    module C = Category C
+  p[_] : C.ob → Type ℓp
+  p[ x ] = ⟨ P ⟅ x ⟆ ⟩
+
+  _⋆_ : ∀ {x y} (f : C [ x , y ]) (g : p[ y ]) → p[ x ]
+  f ⋆ g = P .F-hom f g
+
+  ⋆IdL : ∀ {x} (g : p[ x ]) → C.id ⋆ g ≡ g
+  ⋆IdL = funExt⁻ (P .F-id)
+
+  ⋆Assoc : ∀ {x y z} (f : C [ x , y ])(g : C [ y , z ])(h : p[ z ]) →
+    (f C.⋆ g) ⋆ h ≡ f ⋆ (g ⋆ h)
+  ⋆Assoc f g = funExt⁻ (P .F-seq g f)
+
+  ⟨_⟩⋆⟨_⟩ : ∀ {x y} {f f' : C [ x , y ]} {g g' : p[ y ]}
+          → f ≡ f' → g ≡ g' → f ⋆ g ≡ f' ⋆ g'
+  ⟨ f≡f' ⟩⋆⟨ g≡g' ⟩ = cong₂ _⋆_ f≡f' g≡g'
+
 module UniversalElementNotation {ℓo}{ℓh}
        {C : Category ℓo ℓh} {ℓp} {P : Presheaf C ℓp}
        (ue : UniversalElement C P)
        where
+  open Category
   open UniversalElement ue public
   open NatTrans
   open NatIso


### PR DESCRIPTION
Subsumes (https://github.com/maxsnew/cubical-categorical-logic/pull/124).

This PR is to defined displayed Exponentials (closing https://github.com/maxsnew/cubical-categorical-logic/issues/122). In the process it defines the minimal amount of displayed infrastructure to display over the definition of exponentials. I ended up tweaking some definitions of binary products with a fixed object to minimize the amount I needed to define without losing any of the nice definitional behavior we worked so hard on.

There's also some QoL stuff. Mainly a direct proof of FunctorComprehension that is much faster to type check and some extensions to PresheafNotation and Presheaf^DNotation, though I haven't really needed Presheaf^DNotation as much as I thought I would because we get most things directly from \int P. I also made a bunch of the proofs in PresheafNotation and Presheaf^DNotation opaque since I assume that can only make type checking faster.