### PR TITLE
get compiling with 2.8.0, make FunctorComprehension args explicit

### DIFF
--- a/Cubical/Categories/Displayed/Constructions/Comma.agda
+++ b/Cubical/Categories/Displayed/Constructions/Comma.agda
@@ -47,12 +47,13 @@ open NatTrans
 
 module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'}{E : Category ℓE ℓE'}
          (F : Functor C E) (G : Functor D E) where
-
+  private
+    GraphProf = (HomBif E ∘Fl (F ^opF) ∘Fr G)
   Commaᴰ : Categoryᴰ (C ×C D) ℓE' ℓE'
-  Commaᴰ = Graph {C = C} (HomBif E ∘Fl (F ^opF) ∘Fr G)
+  Commaᴰ = Graph {C = C} GraphProf
 
   hasPropHomsCommaᴰ : hasPropHoms Commaᴰ
-  hasPropHomsCommaᴰ = hasPropHomsGraph _
+  hasPropHomsCommaᴰ = hasPropHomsGraph GraphProf
 
   -- Universal Property: a functor into the comma category is
   -- equivalent to a natural transformation
@@ -72,20 +73,19 @@ module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'}{E : Category ℓE �
   Commaᴰ₁ : Categoryᴰ C (ℓ-max ℓD ℓE') (ℓ-max ℓD' ℓE')
   Commaᴰ₁ = ∫Cᴰsr Commaᴰ
 
-  private
-    IsoCommaᴰ' : Categoryᴰ (∫C Commaᴰ) _ _
-    IsoCommaᴰ' = (PropertyOver _ (λ (_ , f) → isIso E f))
+  IsoCommaᴰ' : Categoryᴰ (∫C Commaᴰ) _ _
+  IsoCommaᴰ' = (PropertyOver _ (λ (_ , f) → isIso E f))
 
-    hasPropHomsIsoCommaᴰ' : hasPropHoms IsoCommaᴰ'
-    hasPropHomsIsoCommaᴰ' =
-      hasContrHoms→hasPropHoms IsoCommaᴰ' (hasContrHomsPropertyOver _ _)
+  hasContrHomsIsoCommaᴰ' : hasContrHoms IsoCommaᴰ'
+  hasContrHomsIsoCommaᴰ' = hasContrHomsPropertyOver (∫C Commaᴰ) λ _ → isIso E _
 
   IsoCommaᴰ : Categoryᴰ (C ×C D) (ℓ-max ℓE' ℓE') ℓE'
   IsoCommaᴰ = ∫Cᴰ Commaᴰ IsoCommaᴰ'
 
   hasPropHomsIsoCommaᴰ : hasPropHoms IsoCommaᴰ
   hasPropHomsIsoCommaᴰ =
-    hasPropHoms∫Cᴰ IsoCommaᴰ' hasPropHomsCommaᴰ hasPropHomsIsoCommaᴰ'
+    hasPropHoms∫Cᴰ IsoCommaᴰ' hasPropHomsCommaᴰ
+      (hasContrHoms→hasPropHoms IsoCommaᴰ' hasContrHomsIsoCommaᴰ')
 
   IsoComma : Category _ _
   IsoComma = ∫C IsoCommaᴰ
@@ -246,4 +246,5 @@ module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'}{E : Category ℓE �
       (mkPropHomsSection (hasPropHomsCommaᴰ _ _)
         (α .trans ⟦_⟧)
         (α .trans .N-hom))
-      (mkContrHomsSection (hasContrHomsPropertyOver _ _) (α .nIso)))
+      (mkContrHomsSection (hasContrHomsIsoCommaᴰ' _ _) (α .nIso)
+      ))

--- a/Cubical/Categories/Displayed/FunctorComprehension.agda
+++ b/Cubical/Categories/Displayed/FunctorComprehension.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --safe  --lossy-unification #-}
+{-# OPTIONS --safe --lossy-unification #-}
 {--
  -- Displayed Functor Comprehension
  -- Construction of a Displayed Functor by defining displayed universal elements
@@ -35,19 +35,19 @@ private
 module _ {C : Category ℓC ℓC'}{D : Category ℓD ℓD'}
          {P : Profunctor C D ℓS}
          {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'} {Dᴰ : Categoryᴰ D ℓDᴰ ℓDᴰ'}
-         {Pᴰ : Profunctorᴰ P Cᴰ Dᴰ ℓSᴰ}
+         (Pᴰ : Profunctorᴰ P Cᴰ Dᴰ ℓSᴰ)
          {ues : UniversalElements P}
          (uesᴰ : UniversalElementsᴰ ues Pᴰ)
        where
   private
     ∫FunctorComprehension : Functor (TotalCat.∫C Cᴰ) (TotalCat.∫C Dᴰ)
     ∫FunctorComprehension =
-      FunctorComprehension (∫UEs Pᴰ uesᴰ :> UniversalElements (∫Prof Pᴰ))
+      FunctorComprehension (∫Prof Pᴰ) (∫UEs Pᴰ uesᴰ)
     module Dᴰ = Reasoning Dᴰ
 
   open Functor
   open Functorᴰ
-  FunctorᴰComprehension : Functorᴰ (FunctorComprehension ues) Cᴰ Dᴰ
+  FunctorᴰComprehension : Functorᴰ (FunctorComprehension P ues) Cᴰ Dᴰ
   FunctorᴰComprehension .F-obᴰ xᴰ = (∫FunctorComprehension ⟅ _ , xᴰ ⟆) .snd
   FunctorᴰComprehension .F-homᴰ fᴰ = (∫FunctorComprehension ⟪ _ , fᴰ ⟫) .snd
   FunctorᴰComprehension .Functorᴰ.F-idᴰ =
@@ -66,5 +66,5 @@ module _ {C : Category ℓC ℓC'}
   -- morphisms
   FunctorⱽComprehension : Functorⱽ Cᴰ Dᴰ
   FunctorⱽComprehension = reindF (Functor≡ (λ _ → refl) (Category.⋆IdL C)) $
-    FunctorᴰComprehension {P = YO} {Pᴰ = Pᴰ} λ x xᴰ →
+    FunctorᴰComprehension Pᴰ λ x xᴰ →
       UniversalElementⱽ.toUniversalᴰ (uesⱽ x xᴰ)

--- a/Cubical/Categories/Displayed/Limits/BinProduct/Base.agda
+++ b/Cubical/Categories/Displayed/Limits/BinProduct/Base.agda
@@ -62,7 +62,7 @@ module _ {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓD ℓD') where
   a×-Fᴰ : ∀ {c}  {c×- : hasAllBinProductWith C c}
             {cᴰ} (cᴰ×ᴰ- : hasAllBinProductWithᴰ c×- cᴰ)
           → Functorᴰ (a×-F C c×-) Cᴰ Cᴰ
-  a×-Fᴰ {cᴰ = cᴰ} cᴰ×ᴰ- = FunctorᴰComprehension {Pᴰ = ProdWithAProfᴰ cᴰ} cᴰ×ᴰ-
+  a×-Fᴰ {cᴰ = cᴰ} cᴰ×ᴰ- = FunctorᴰComprehension (ProdWithAProfᴰ cᴰ) cᴰ×ᴰ-
 
   BinProductⱽ : ∀ {c} → (Cᴰ.ob[ c ] × Cᴰ.ob[ c ]) → Type _
   BinProductⱽ = RightAdjointAtⱽ (Δᴰ Cᴰ)

--- a/Cubical/Categories/Exponentials.agda
+++ b/Cubical/Categories/Exponentials.agda
@@ -61,7 +61,7 @@ module _ (C : Category ℓC ℓC') where
 
     ExponentialF : Exponentials → Functor ((C ^op) ×C C) C
     ExponentialF exps =
-      FunctorComprehension {P = RightAdjointLProf ×Bif} exps ∘F Prod.Sym
+      FunctorComprehension (RightAdjointLProf ×Bif) exps ∘F Prod.Sym
     open UniversalElement
 
     module ExpsNotation (exp : Exponentials) where

--- a/Cubical/Categories/FunctorComprehension.agda
+++ b/Cubical/Categories/FunctorComprehension.agda
@@ -49,7 +49,7 @@ open UniversalElement
 open UniversalElementNotation
 
 module _ {C : Category ℓC ℓC'}{D : Category ℓD ℓD'}
-         {P : Profunctor C D ℓS}
+         (P : Profunctor C D ℓS)
          (ues : UniversalElements P)
          where
   private

--- a/Cubical/Categories/Limits/AsRepresentable.agda
+++ b/Cubical/Categories/Limits/AsRepresentable.agda
@@ -47,7 +47,7 @@ limitsOfShape C J =
 limitF : {C : Category ℓc ℓc'}{J : Category ℓj ℓj'}
   → limitsOfShape C J → Functor (FUNCTOR J C) C
 limitF {C = C}{J = J} lims =
-  FunctorComprehension {C = FUNCTOR J C}{D = C} {P = RightAdjointProf ΔCone}
+  FunctorComprehension {C = FUNCTOR J C}{D = C} (RightAdjointProf ΔCone)
     lims
 
 -- TODO: All functors preserve cones

--- a/Cubical/Categories/Limits/BinProduct/More.agda
+++ b/Cubical/Categories/Limits/BinProduct/More.agda
@@ -123,7 +123,7 @@ module _ (C : Category ℓ ℓ') where
     BinProductsToUnivElts c = BinProductToRepresentable (bp (c .fst) (c .snd))
 
     BinProductF : Functor (C R.×C C) C
-    BinProductF = FunctorComprehension BinProductsToUnivElts
+    BinProductF = FunctorComprehension BinProductProf BinProductsToUnivElts
 
     BinProductF' : Functor (C ×C C) C
     BinProductF' = BinProductF ∘F R.ProdToRedundant C C
@@ -137,14 +137,14 @@ module _ (C : Category ℓ ℓ') where
       f g h : C [ a , b ]
   module _ {a} (a×- : hasAllBinProductWith a) where
     a×-F : Functor C C
-    a×-F = FunctorComprehension a×-
+    a×-F = FunctorComprehension (ProdWithAProf a) a×-
 
   module _ {a} (bp : ∀ b → BinProduct C a b) where
     BinProductWithToRepresentable : UniversalElements (ProdWithAProf a)
     BinProductWithToRepresentable b = BinProductToRepresentable (bp b)
 
     BinProductWithF =
-      FunctorComprehension BinProductWithToRepresentable
+      FunctorComprehension (ProdWithAProf a) BinProductWithToRepresentable
 
     -- test definitional behavior
     _ : ∀ {b b'}(f : C [ b , b' ]) →
@@ -198,7 +198,7 @@ module _ (C : Category ℓ ℓ') where
     BinProduct'WithUEs b .universal = bp b .universal
 
     BinProduct'WithF : Functor C C
-    BinProduct'WithF = FunctorComprehension BinProduct'WithUEs
+    BinProduct'WithF = FunctorComprehension (ProdWithAProf a) BinProduct'WithUEs
 
   module NotationAt {a b : C .ob} (bp : BinProduct C a b) where
     private


### PR DESCRIPTION
2.8.0 led to a lot of args no longer being inferrable, even with --lossy-unification. FunctorComprehension was so affected by this that I just made the profunctor argument explicit