### PR TITLE
Generate and Deploy HTML

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,3 +189,21 @@ jobs:
         with:
           path: ~/cubical/_build
           key: ${{ steps.cache-cubical-library-restore.outputs.cache-primary-key }}
+
+      ########################################################################
+      ## HTML GENERATION
+      ########################################################################
+
+      - name: Htmlize cubical
+        if: github.event_name == 'push' && github.ref_name == 'master'
+        run: |
+          make listings \
+            AGDA_EXEC='~/.cabal/bin/agda -WnoUnsupportedIndexedMatch -W error' \
+            FIX_WHITESPACE='~/.local/fix-whitespace/bin/fix-whitespace'
+
+      - name: Deploy to GitHub Pages
+        if: github.event_name == 'push' && github.ref_name == 'master'
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: html


### PR DESCRIPTION
Testing that the github workflow runs correctly with this PR

This should generate all HTML needed for the library into an `html` directory then puts it on the `gh-pages` branch, which I believe should be accessible at [https://maxsnew.github.io/cubical-categorical-logic]]

This also builds `html` for any `cubical` standard library dependencies