### PR TITLE
Vertical Exponentials for Displayed Sets

### DIFF
--- a/Cubical/Categories/Displayed/Instances/Sets/Properties.agda
+++ b/Cubical/Categories/Displayed/Instances/Sets/Properties.agda
@@ -119,43 +119,34 @@ module _ {ℓ} {ℓ'} where
   FiberExponentialSETᴰ A Aᴰ Aᴰ' .vertex a .fst = ⟨ Aᴰ a ⟩ → ⟨ Aᴰ' a ⟩
   FiberExponentialSETᴰ A Aᴰ Aᴰ' .vertex a .snd = isSet→ (str (Aᴰ' a))
   FiberExponentialSETᴰ A Aᴰ Aᴰ' .element a (f , aᴰ) = f aᴰ
-  FiberExponentialSETᴰ A Aᴰ Aᴰ' .universal Aᴰ'' .equiv-proof f .fst .fst a aᴰ'' aᴰ =
-    f a (aᴰ'' , aᴰ)
-  FiberExponentialSETᴰ A Aᴰ Aᴰ' .universal Aᴰ'' .equiv-proof f .fst .snd =
-    fromPathP (λ i →
-      transport-filler (λ j → (a : ⟨ A ⟩) → ⟨ Aᴰ'' a ⟩ × ⟨ Aᴰ a ⟩ → ⟨ Aᴰ' a ⟩)
-                        f (~ i)
-    )
-  FiberExponentialSETᴰ A Aᴰ Aᴰ' .universal Aᴰ'' .equiv-proof f .snd (g , x) =
-    ΣPathP (
-      funExt₂ (λ a aᴰ'' → funExt λ aᴰ → sym (funExt⁻ (funExt⁻ x a) (aᴰ'' , aᴰ)))
-      ∙ fromPathP (λ i →
-          transport-filler (λ j → (a : ⟨ A ⟩) → ⟨ Aᴰ'' a ⟩ → ⟨ Aᴰ a ⟩ → ⟨ Aᴰ' a ⟩)
-                            g (~ i)
-        ) ,
-      isSet→SquareP (λ _ _ →
-        str (ExponentiableProf _ (bpw Aᴰ) .F-ob Aᴰ' .F-ob Aᴰ'')) _ _ _ _
+  FiberExponentialSETᴰ A Aᴰ Aᴰ' .universal Aᴰ'' =
+    isIsoToIsEquiv (
+      (λ f a aᴰ'' aᴰ → f a (aᴰ'' , aᴰ)) ,
+      (λ f → fromPathP
+        (λ i → transport-filler
+          (λ j → (a : ⟨ A ⟩) → ⟨ Aᴰ'' a ⟩ × ⟨ Aᴰ a ⟩ → ⟨ Aᴰ' a ⟩) f (~ i))),
+      (λ f  → fromPathP
+        (λ i → transport-filler
+          (λ j → (a : ⟨ A ⟩) → ⟨ Aᴰ'' a ⟩ → ⟨ Aᴰ a ⟩ → ⟨ Aᴰ' a ⟩) f (~ i))
+      )
     )
 
   open Exponentialⱽ
   open UniversalElementNotation
   ExponentialsⱽSETᴰ : Exponentialsⱽ (SETᴰ ℓ ℓ') BinProductsⱽSETᴰ isFibrationSETᴰ
   ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .cᴰ⇒cᴰ' = FiberExponentialSETᴰ A Aᴰ Aᴰ'
-  ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof gᴰ =
-    ((λ b bᴰ aᴰ → gᴰ b (bᴰ , aᴰ)) ,
-     (λ i → ×f*Aᴰ.×aF .F-hom (ExpB.lda gᴰ) ⋆⟨ SETᴰ.v[ B ] ⟩ preserves-elt i)
-     ∙ ExpB.β⇒ gᴰ
-    ) ,
-    (λ (hᴰ , x) →
-      ΣPathP (
-        (funExt₂ λ b bᴰ → funExt λ faᴰ →
-          (sym $ funExt⁻ (funExt⁻ x b) (bᴰ , faᴰ))
-          ∙ (λ i → (×f*Aᴰ.×aF .F-hom hᴰ ⋆⟨ SETᴰ.v[ B ] ⟩ preserves-elt i) b (bᴰ , faᴰ))
-          ∙ funExt⁻ (funExt⁻ (ExpB.β⇒ _) b) ((bᴰ , faᴰ))
-        ) ,
-    isSet→SquareP (λ _ _ →
-      str (ExponentiableProf _ (bpw (f*F ⟅ Aᴰ ⟆))
-             .F-ob (f*F ⟅ Aᴰ' ⟆) .F-ob Bᴰ)) _ _ _ _))
+  ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ =
+    isIsoToIsEquiv (
+      (λ gᴰ b bᴰ faᴰ → gᴰ b (bᴰ , faᴰ)) ,
+      (λ gᴰ →
+        (λ i → ×f*Aᴰ.×aF .F-hom (ExpB.lda gᴰ) ⋆⟨ SETᴰ.v[ B ] ⟩ preserves-elt i)
+        ∙ ExpB.β⇒ gᴰ
+      ) ,
+      (λ gᴰ → funExt₃ λ b bᴰ faᴰ →
+        (λ i → (×f*Aᴰ.×aF .F-hom gᴰ ⋆⟨ SETᴰ.v[ B ] ⟩ preserves-elt i) b (bᴰ , faᴰ))
+        ∙ funExt⁻ (funExt⁻ (ExpB.β⇒ _) b) ((bᴰ , faᴰ))
+      )
+    )
     where
     f*F : Functor SETᴰ.v[ A ] SETᴰ.v[ B ]
     f*F = CartesianLiftF-fiber (SETᴰ ℓ ℓ') isFibrationSETᴰ f

--- a/Cubical/Categories/Displayed/Instances/Sets/Properties.agda
+++ b/Cubical/Categories/Displayed/Instances/Sets/Properties.agda
@@ -127,9 +127,7 @@ module _ {ℓ} {ℓ'} where
           (λ j → (a : ⟨ A ⟩) → ⟨ Aᴰ'' a ⟩ × ⟨ Aᴰ a ⟩ → ⟨ Aᴰ' a ⟩) f (~ i))),
       (λ f  → fromPathP
         (λ i → transport-filler
-          (λ j → (a : ⟨ A ⟩) → ⟨ Aᴰ'' a ⟩ → ⟨ Aᴰ a ⟩ → ⟨ Aᴰ' a ⟩) f (~ i))
-      )
-    )
+          (λ j → (a : ⟨ A ⟩) → ⟨ Aᴰ'' a ⟩ → ⟨ Aᴰ a ⟩ → ⟨ Aᴰ' a ⟩) f (~ i))))
 
   open Exponentialⱽ
   open UniversalElementNotation
@@ -139,20 +137,13 @@ module _ {ℓ} {ℓ'} where
     isIsoToIsEquiv (
       (λ gᴰ b bᴰ faᴰ → gᴰ b (bᴰ , faᴰ)) ,
       (λ gᴰ →
-        (λ i → ×f*Aᴰ.×aF .F-hom (ExpB.lda gᴰ) ⋆⟨ SETᴰ.v[ B ] ⟩ preserves-elt i)
-        ∙ β (FiberExponentialSETᴰ _ _ _)
+        cong₂ (seq' SETᴰ.v[ B ]) refl (ExpB.⇒ue.β _ _)
+        ∙ ExpB.⇒ue.β _ _
       ) ,
       (λ gᴰ → funExt₃ λ b bᴰ faᴰ →
-        (λ i → (×f*Aᴰ.×aF .F-hom gᴰ ⋆⟨ SETᴰ.v[ B ] ⟩ preserves-elt i) b (bᴰ , faᴰ))
-        ∙ funExt⁻ (funExt⁻ (β (FiberExponentialSETᴰ _ _ _)) b) ((bᴰ , faᴰ))
-      )
+        funExt⁻ (funExt⁻
+          (cong₂ (seq' SETᴰ.v[ B ]) refl (ExpB.⇒ue.β _ _) ∙ ExpB.⇒ue.β _ _)
+        b) (bᴰ , faᴰ))
     )
     where
-    f*F : Functor SETᴰ.v[ A ] SETᴰ.v[ B ]
-    f*F = CartesianLiftF-fiber (SETᴰ ℓ ℓ') isFibrationSETᴰ f
-
-    module ×f*Aᴰ = BinProductsWithNotation (bpw (f*F ⟅ Aᴰ ⟆))
     module ExpB = ExponentialsNotation (bp B) (FiberExponentialSETᴰ B)
-
-    preserves-elt = β (FiberExponentialSETᴰ B
-                         (f*F ⟅ Aᴰ ⟆) (f*F ⟅ Aᴰ' ⟆)) {p = ExpB.app}

--- a/Cubical/Categories/Displayed/Instances/Sets/Properties.agda
+++ b/Cubical/Categories/Displayed/Instances/Sets/Properties.agda
@@ -129,4 +129,49 @@ module _ {ℓ} {ℓ'} where
   open Exponentialⱽ
   ExponentialsⱽSETᴰ : Exponentialsⱽ (SETᴰ ℓ ℓ') BinProductsⱽSETᴰ isFibrationSETᴰ
   ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .cᴰ⇒cᴰ' = FiberExponentialSETᴰ A Aᴰ Aᴰ'
-  ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ = {!!}
+  ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof g .fst .fst b bᴰ aᴰ = g b (bᴰ , aᴰ)
+  ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof g .fst .snd =
+    -- TODO : Stuck here
+    -- action SETᴰ.v[ B ]
+    --  (F-ob
+    --   (ExponentiableProf SETᴰ.v[ B ]
+    --    (BinProductsWithⱽ→BinProductsWithFiber (SETᴰ ℓ ℓ')
+    --     (λ cᴰ'' →
+    --        BinProductsⱽSETᴰ B
+    --        (cᴰ'' ,
+    --         F-ob (CartesianLiftF-fiber (SETᴰ ℓ ℓ') isFibrationSETᴰ f) Aᴰ))))
+    --   (F-ob (CartesianLiftF-fiber (SETᴰ ℓ ℓ') isFibrationSETᴰ f) Aᴰ'))
+    --  (ExponentialsⱽSETᴰ Aᴰ Aᴰ' .reindex⇒ f Bᴰ .equiv-proof g .fst .fst)
+    --  (preservesExpCone
+    --   (CartesianLiftF-fiber (SETᴰ ℓ ℓ') isFibrationSETᴰ f)
+    --   (BinProductsWithⱽ→BinProductsWithFiber (SETᴰ ℓ ℓ')
+    --    (λ cᴰ'' → BinProductsⱽSETᴰ A (cᴰ'' , Aᴰ)))
+    --   (λ z →
+    --      cartesianLift-preserves-BinProductFiber (SETᴰ ℓ ℓ') isFibrationSETᴰ
+    --      (BinProductsⱽSETᴰ A (z , Aᴰ)) f)
+    --   (BinProductsWithⱽ→BinProductsWithFiber (SETᴰ ℓ ℓ')
+    --    (λ cᴰ'' →
+    --       BinProductsⱽSETᴰ B
+    --       (cᴰ'' ,
+    --        F-ob (CartesianLiftF-fiber (SETᴰ ℓ ℓ') isFibrationSETᴰ f) Aᴰ)))
+    --   Aᴰ' .fst (ExponentialsⱽSETᴰ Aᴰ Aᴰ' .cᴰ⇒cᴰ' .vertex)
+    --   (ExponentialsⱽSETᴰ Aᴰ Aᴰ' .cᴰ⇒cᴰ' .element))
+    {!!}
+    ≡⟨ {!!} ⟩
+    g
+    ∎
+    where
+    --                  g
+    -- Bᴰ ×ⱽ f* Aᴰ -------------> Aᴰ'
+    --    |                       |
+    --    |                       |
+    --    |                       |
+    --    v                       v
+    --    B --------------------> A
+    --             f
+    g' : (SETᴰ ℓ ℓ') [ f ][ BinProductsⱽSETᴰ B (Bᴰ , (CartesianLiftF-fiber (SETᴰ ℓ ℓ') isFibrationSETᴰ f) .F-ob Aᴰ) .vertexⱽ , Aᴰ' ]
+    g' = g
+    -- funExt₂ (λ where
+    --   b (bᴰ , aᴰ) → {!g!}
+    -- )
+  ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof g .snd = {!!}

--- a/Cubical/Categories/Displayed/Instances/Sets/Properties.agda
+++ b/Cubical/Categories/Displayed/Instances/Sets/Properties.agda
@@ -134,19 +134,46 @@ module _ {ℓ} {ℓ'} where
       isSet→SquareP (λ _ _ → str (RightAdjointProf (BinProductWithF SETᴰ.v[ A ] (bpw Aᴰ)) .F-ob Aᴰ' .F-ob Aᴰ'')) _ _ _ _
       )
 
+  open import Cubical.Categories.Yoneda
   open Exponentialⱽ
+  open UniversalElementNotation
   ExponentialsⱽSETᴰ : Exponentialsⱽ (SETᴰ ℓ ℓ') BinProductsⱽSETᴰ isFibrationSETᴰ
   ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .cᴰ⇒cᴰ' = FiberExponentialSETᴰ A Aᴰ Aᴰ'
   ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof gᴰ .fst .fst b bᴰ aᴰ = gᴰ b (bᴰ , aᴰ)
   ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof gᴰ .fst .snd =
-    λgᴰ PB.⋆ app'
-      ≡⟨ {!!} ⟩
-    (introCL CLAᴰ⇒Aᴰ' λgᴰ') PB.⋆ (α (Aᴰ ⇒A Aᴰ') ExpA.app)
-      ≡⟨ {!sym $ α-natural ? ? ? ?!} ⟩
-    {!!}
-      ≡⟨ {!!} ⟩
-    gᴰ
-    ∎
+    funExt₂ (λ where
+      b (bᴰ , x) →
+        -- I don't think this is the best way to solve this equality, but I have exhausted all
+        -- ideas other than expanding everything defintionally
+        -- (λgᴰ PB.⋆ app') b (bᴰ , x)
+        --   ≡⟨ refl ⟩
+        -- expPshB .F-hom λgᴰ app' b (bᴰ , x)
+        --   ≡⟨ refl ⟩
+        ((SETᴰ.v[ B ] [-, (f* Aᴰ') ]) ∘F (BinProductWithF _ (bpw (f* Aᴰ)) ^opF))
+          .F-hom λgᴰ app' b (bᴰ , x)
+          ≡⟨ refl ⟩
+        (SETᴰ.v[ B ] [-, (f* Aᴰ') ]) .F-hom ((BinProductWithF _ (bpw (f* Aᴰ)) ^opF) .F-hom λgᴰ)
+          app' b (bᴰ , x)
+          ≡⟨ refl ⟩
+          -- ?1 is some term with an intro?
+        (SETᴰ.v[ B ] [-, (f* Aᴰ') ]) .F-hom {!!}
+          app' b (bᴰ , x)
+          ≡⟨ refl ⟩
+        {!!}
+          ≡⟨ {!!} ⟩
+        {!!}
+          ≡⟨ {!!} ⟩
+        {!!}
+          ≡⟨ {!!} ⟩
+        gᴰ b (bᴰ , x)
+        ∎
+    )
+    -- λgᴰ PB.⋆ app'
+    --   ≡⟨ {!!} ⟩
+    -- (introCL CLAᴰ⇒Aᴰ' λgᴰ') PB.⋆ (α (Aᴰ ⇒A Aᴰ') ExpA.app)
+    --   ≡⟨ {!!} ⟩
+    -- gᴰ
+    -- ∎
     where
     f*F : Functor SETᴰ.v[ A ] SETᴰ.v[ B ]
     f*F = CartesianLiftF-fiber (SETᴰ ℓ ℓ') isFibrationSETᴰ f
@@ -203,8 +230,17 @@ module _ {ℓ} {ℓ'} where
     λgᴰ≡ : λgᴰ ≡ introCL CLAᴰ⇒Aᴰ' λgᴰ'
     λgᴰ≡ = ηᴰCL CLAᴰ⇒Aᴰ'
 
-    u : introCL CLAᴰ⇒Aᴰ' λgᴰ' ≡ {!!}
-    u = {!!}
+    u : expPshB .F-hom λgᴰ ≡ λ ϕ → λgᴰ ×pB (SETᴰ.v[ B ] .id) ⋆⟨ SETᴰ.v[ B ] ⟩ ϕ
+    u =
+      -- fromPathP (λ i → transport-filler (λ j → (x : expPshB .F-ob (f* (Aᴰ ⇒A Aᴰ')) .fst) →
+      --                                            (b : ⟨ B ⟩) →
+      --                                            ⟨ Bᴰ b ⟩ × ⟨ Aᴰ (f b) ⟩ →
+      --                                            {!⟨ Aᴰ' (f b) ⟩!})
+      --                    (expPshB .F-hom λgᴰ) i)
+      funExt₂
+      (λ where x b → funExt λ where
+        (bᴰ , aᴰ) → {!!}
+      )
 
     -- precompλgᴰ×id : SETᴰ.v[ B ] [ (f* (Aᴰ ⇒A Aᴰ')) ×B (f* Aᴰ) , f* Aᴰ' ] →
     --                SETᴰ.v[ B ] [  Bᴰ ×B (f* Aᴰ) , f* Aᴰ' ]

--- a/Cubical/Categories/Displayed/Instances/Sets/Properties.agda
+++ b/Cubical/Categories/Displayed/Instances/Sets/Properties.agda
@@ -22,6 +22,8 @@ open import Cubical.Categories.Instances.Sets
 open import Cubical.Categories.Instances.Sets.More
 open import Cubical.Categories.Instances.Sets.Properties
 open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.More
+open import Cubical.Categories.Presheaf.Morphism.Alt
 open import Cubical.Categories.Presheaf.Representable
 open import Cubical.Categories.Displayed.Base
 open import Cubical.Categories.Exponentials
@@ -48,6 +50,7 @@ open UniversalElementᴰ
 open UniversalElementⱽ
 open CartesianLift
 open Categoryᴰ
+open Category
 open isIsoOver
 
 isFibrationSETᴰ : isFibration (SETᴰ ℓ ℓ')
@@ -102,17 +105,22 @@ SETᴰCartesianCategoryⱽ ℓ ℓ' .CartesianCategoryⱽ.cartesianLifts = isFib
 module _ {ℓ} {ℓ'} where
   private
     module SETᴰ = Fibers (SETᴰ ℓ ℓ')
+    module C = Category (SET ℓ)
+    module Cᴰ = Categoryᴰ (SETᴰ ℓ ℓ')
 
-    bpw : (A : Category.ob (SET ℓ)) → (Aᴰ Aᴰ' : SETᴰ.ob[ A ]) →
+    bp : (A : SET ℓ .ob) → BinProducts SETᴰ.v[ A ]
+    bp A = BinProductsⱽ→BinProductsFibers (SETᴰ ℓ ℓ') BinProductsⱽSETᴰ
+
+    bpw : {A : Category.ob (SET ℓ)} → (Aᴰ Aᴰ' : SETᴰ.ob[ A ]) →
       UniversalElement SETᴰ.v[ A ] _
-    bpw A Aᴰ =
+    bpw {A = A} Aᴰ =
       (BinProductsWithⱽ→BinProductsWithFiber (SETᴰ ℓ ℓ')
         (λ cᴰ' → BinProductsⱽSETᴰ A (cᴰ' , Aᴰ)))
 
   open Functor
   open UniversalElement
   FiberExponentialSETᴰ : (A : Category.ob (SET ℓ)) → (Aᴰ Aᴰ' : SETᴰ.ob[ A ]) →
-    Exponential SETᴰ.v[ A ] Aᴰ Aᴰ' (bpw A Aᴰ)
+    Exponential SETᴰ.v[ A ] Aᴰ Aᴰ' (bpw Aᴰ)
   FiberExponentialSETᴰ A Aᴰ Aᴰ' .vertex a .fst = ⟨ Aᴰ a ⟩ → ⟨ Aᴰ' a ⟩
   FiberExponentialSETᴰ A Aᴰ Aᴰ' .vertex a .snd = isSet→ (str (Aᴰ' a))
   FiberExponentialSETᴰ A Aᴰ Aᴰ' .element a (f , aᴰ) = f aᴰ
@@ -123,45 +131,86 @@ module _ {ℓ} {ℓ'} where
     ΣPathP (
       funExt₂ (λ a aᴰ'' → funExt λ aᴰ → sym (funExt⁻ (funExt⁻ x a) (aᴰ'' , aᴰ)))
       ∙ fromPathP (λ i → transport-filler (λ j → (a : ⟨ A ⟩) → ⟨ Aᴰ'' a ⟩ → ⟨ Aᴰ a ⟩ → ⟨ Aᴰ' a ⟩) g (~ i)) ,
-      isSet→SquareP (λ _ _ → str (RightAdjointProf (BinProductWithF SETᴰ.v[ A ] (bpw A Aᴰ)) .F-ob Aᴰ' .F-ob Aᴰ'')) _ _ _ _
+      isSet→SquareP (λ _ _ → str (RightAdjointProf (BinProductWithF SETᴰ.v[ A ] (bpw Aᴰ)) .F-ob Aᴰ' .F-ob Aᴰ'')) _ _ _ _
       )
 
   open Exponentialⱽ
   ExponentialsⱽSETᴰ : Exponentialsⱽ (SETᴰ ℓ ℓ') BinProductsⱽSETᴰ isFibrationSETᴰ
   ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .cᴰ⇒cᴰ' = FiberExponentialSETᴰ A Aᴰ Aᴰ'
-  ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof g .fst .fst b bᴰ aᴰ = g b (bᴰ , aᴰ)
-  ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof g .fst .snd =
-    -- TODO : Stuck here
-    -- action SETᴰ.v[ B ]
-    --  (F-ob
-    --   (ExponentiableProf SETᴰ.v[ B ]
-    --    (BinProductsWithⱽ→BinProductsWithFiber (SETᴰ ℓ ℓ')
-    --     (λ cᴰ'' →
-    --        BinProductsⱽSETᴰ B
-    --        (cᴰ'' ,
-    --         F-ob (CartesianLiftF-fiber (SETᴰ ℓ ℓ') isFibrationSETᴰ f) Aᴰ))))
-    --   (F-ob (CartesianLiftF-fiber (SETᴰ ℓ ℓ') isFibrationSETᴰ f) Aᴰ'))
-    --  (ExponentialsⱽSETᴰ Aᴰ Aᴰ' .reindex⇒ f Bᴰ .equiv-proof g .fst .fst)
-    --  (preservesExpCone
-    --   (CartesianLiftF-fiber (SETᴰ ℓ ℓ') isFibrationSETᴰ f)
-    --   (BinProductsWithⱽ→BinProductsWithFiber (SETᴰ ℓ ℓ')
-    --    (λ cᴰ'' → BinProductsⱽSETᴰ A (cᴰ'' , Aᴰ)))
-    --   (λ z →
-    --      cartesianLift-preserves-BinProductFiber (SETᴰ ℓ ℓ') isFibrationSETᴰ
-    --      (BinProductsⱽSETᴰ A (z , Aᴰ)) f)
-    --   (BinProductsWithⱽ→BinProductsWithFiber (SETᴰ ℓ ℓ')
-    --    (λ cᴰ'' →
-    --       BinProductsⱽSETᴰ B
-    --       (cᴰ'' ,
-    --        F-ob (CartesianLiftF-fiber (SETᴰ ℓ ℓ') isFibrationSETᴰ f) Aᴰ)))
-    --   Aᴰ' .fst (ExponentialsⱽSETᴰ Aᴰ Aᴰ' .cᴰ⇒cᴰ' .vertex)
-    --   (ExponentialsⱽSETᴰ Aᴰ Aᴰ' .cᴰ⇒cᴰ' .element))
+  ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof gᴰ .fst .fst b bᴰ aᴰ = gᴰ b (bᴰ , aᴰ)
+  ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof gᴰ .fst .snd =
+    λgᴰ PB.⋆ app'
+      ≡⟨ {!!} ⟩
+    (introCL CLAᴰ⇒Aᴰ' λgᴰ') PB.⋆ (α (Aᴰ ⇒A Aᴰ') ExpA.app)
+      ≡⟨ {!sym $ α-natural ? ? ? ?!} ⟩
     {!!}
-    ≡⟨ {!!} ⟩
-    g
+      ≡⟨ {!!} ⟩
+    gᴰ
     ∎
     where
-    --                  g
+    f*F : Functor SETᴰ.v[ A ] SETᴰ.v[ B ]
+    f*F = CartesianLiftF-fiber (SETᴰ ℓ ℓ') isFibrationSETᴰ f
+
+    f*_ : SETᴰ.v[ A ] .ob → SETᴰ.v[ B ] .ob
+    f*_ = f*F .F-ob
+
+    module bpA = BinProductsNotation (bp A)
+    module bpB = BinProductsNotation (bp B)
+
+    _,pA_ = bpA._,p_
+    _,pB_ = bpB._,p_
+    _×A_ = bpA._×_
+    _×pA_ = bpA._×p_
+    _×B_ = bpB._×_
+    _×pB_ = bpB._×p_
+
+    module ExpA = ExponentialsNotation (bp A) (FiberExponentialSETᴰ A)
+    module ExpB = ExponentialsNotation (bp B) (FiberExponentialSETᴰ B)
+
+    _⇒A_ = ExpA._⇒_
+    _⇒B_ = ExpB._⇒_
+
+    CLAᴰ = isFibrationSETᴰ {c = B}{c' = A} Aᴰ f
+    CLAᴰ' = isFibrationSETᴰ {c = B}{c' = A} Aᴰ' f
+    CLAᴰ⇒Aᴰ' = isFibrationSETᴰ {c = B}{c' = A} (Aᴰ ⇒A Aᴰ') f
+    module f*Aᴰ = CartesianLift CLAᴰ
+    module f*Aᴰ' = CartesianLift CLAᴰ'
+    module f*Aᴰ⇒Aᴰ' = CartesianLift CLAᴰ⇒Aᴰ'
+
+    expPshA : Functor (SETᴰ.v[ A ] ^op) (SET (ℓ-max ℓ ℓ'))
+    expPshA = ExponentiableProf SETᴰ.v[ A ] (bpw Aᴰ) .F-ob Aᴰ'
+
+    expPshB : Functor (SETᴰ.v[ B ] ^op) (SET (ℓ-max ℓ ℓ'))
+    expPshB = ExponentiableProf SETᴰ.v[ B ] (bpw (f* Aᴰ)) .F-ob (f* Aᴰ')
+
+    module PA = PresheafNotation expPshA
+    module PB = PresheafNotation expPshB
+
+    --              λgᴰ
+    --    Bᴰ -------------> f* (Aᴰ ⇒A Aᴰ')
+    --    |                       |
+    --    |                       |
+    --    |                       |
+    --    v                       v
+    --    B --------------------> B
+    --             id
+    λgᴰ : SETᴰ.v[ B ] [ Bᴰ , f* (Aᴰ ⇒A Aᴰ') ]
+    λgᴰ = ExpB.lda gᴰ
+
+    λgᴰ' : Cᴰ.Hom[ f ][ Bᴰ , Aᴰ ⇒A Aᴰ' ]
+    λgᴰ' = Cᴰ._⋆ᴰ_ {zᴰ = Aᴰ ⇒A Aᴰ'} λgᴰ f*Aᴰ⇒Aᴰ'.π
+
+    λgᴰ≡ : λgᴰ ≡ introCL CLAᴰ⇒Aᴰ' λgᴰ'
+    λgᴰ≡ = ηᴰCL CLAᴰ⇒Aᴰ'
+
+    u : introCL CLAᴰ⇒Aᴰ' λgᴰ' ≡ {!!}
+    u = {!!}
+
+    -- precompλgᴰ×id : SETᴰ.v[ B ] [ (f* (Aᴰ ⇒A Aᴰ')) ×B (f* Aᴰ) , f* Aᴰ' ] →
+    --                SETᴰ.v[ B ] [  Bᴰ ×B (f* Aᴰ) , f* Aᴰ' ]
+    -- precompλgᴰ×id = expPshB .F-hom λgᴰ
+
+    --                  gᴰ
     -- Bᴰ ×ⱽ f* Aᴰ -------------> Aᴰ'
     --    |                       |
     --    |                       |
@@ -169,9 +218,29 @@ module _ {ℓ} {ℓ'} where
     --    v                       v
     --    B --------------------> A
     --             f
-    g' : (SETᴰ ℓ ℓ') [ f ][ BinProductsⱽSETᴰ B (Bᴰ , (CartesianLiftF-fiber (SETᴰ ℓ ℓ') isFibrationSETᴰ f) .F-ob Aᴰ) .vertexⱽ , Aᴰ' ]
-    g' = g
-    -- funExt₂ (λ where
-    --   b (bᴰ , aᴰ) → {!g!}
-    -- )
-  ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof g .snd = {!!}
+    gᴰ' : (SETᴰ ℓ ℓ') [ f ][ Bᴰ ×B (f* Aᴰ) , Aᴰ' ]
+    gᴰ' = gᴰ
+
+    pshHom : PshHomᴰ f*F expPshA expPshB
+    pshHom = preservesExpCone f*F (λ Aᴰ'' → bp A (Aᴰ'' , Aᴰ))
+        (λ z →
+           cartesianLift-preserves-BinProductFiber (SETᴰ ℓ ℓ') isFibrationSETᴰ
+           (BinProductsⱽSETᴰ A (z , Aᴰ)) f)
+        (bpw (f* Aᴰ)) Aᴰ'
+
+    α : (Aᴰ'' : ob SETᴰ.v[ A ]) → PA.p[ Aᴰ'' ] → PB.p[ f* Aᴰ'' ]
+    α = pshHom .fst
+
+    α-natural : ∀ Aᴰ₁ Aᴰ₂ h x → α Aᴰ₁ (h PA.⋆ x) ≡ ((f*F .F-hom h) PB.⋆ α Aᴰ₂ x)
+    α-natural = pshHom .snd
+
+    app' : SETᴰ.v[ B ] [ (f* (Aᴰ ⇒A Aᴰ')) ×B (f* Aᴰ) , f* Aᴰ' ]
+    app' = α (Aᴰ ⇒A Aᴰ') ExpA.app
+
+    app'' : Cᴰ.Hom[ f ][ (f* (Aᴰ ⇒A Aᴰ')) ×B (f* Aᴰ) , Aᴰ' ]
+    app'' = Cᴰ._⋆ᴰ_ {zᴰ = Aᴰ'} app' f*Aᴰ'.π
+
+    app≡ : app' ≡ introCL CLAᴰ' app''
+    app≡ = ηᴰCL CLAᴰ'
+
+  ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof gᴰ .snd = {!!}

--- a/Cubical/Categories/Displayed/Instances/Sets/Properties.agda
+++ b/Cubical/Categories/Displayed/Instances/Sets/Properties.agda
@@ -130,146 +130,30 @@ module _ {ℓ} {ℓ'} where
     ΣPathP (
       funExt₂ (λ a aᴰ'' → funExt λ aᴰ → sym (funExt⁻ (funExt⁻ x a) (aᴰ'' , aᴰ)))
       ∙ fromPathP (λ i → transport-filler (λ j → (a : ⟨ A ⟩) → ⟨ Aᴰ'' a ⟩ → ⟨ Aᴰ a ⟩ → ⟨ Aᴰ' a ⟩) g (~ i)) ,
-      isSet→SquareP (λ _ _ →
-        str (RightAdjointProf (BinProductWithF SETᴰ.v[ A ] (bpw Aᴰ)) .F-ob Aᴰ' .F-ob Aᴰ'')) _ _ _ _)
+      isSet→SquareP (λ _ _ → str (ExponentiableProf _ (bpw Aᴰ) .F-ob Aᴰ' .F-ob Aᴰ'')) _ _ _ _)
 
   open Exponentialⱽ
   open UniversalElementNotation
   ExponentialsⱽSETᴰ : Exponentialsⱽ (SETᴰ ℓ ℓ') BinProductsⱽSETᴰ isFibrationSETᴰ
   ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .cᴰ⇒cᴰ' = FiberExponentialSETᴰ A Aᴰ Aᴰ'
-  ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof gᴰ .fst .fst b bᴰ aᴰ = gᴰ b (bᴰ , aᴰ)
-  ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof gᴰ .fst .snd =
-    (λ i → ×aF .F-hom λgᴰ ⋆⟨ SETᴰ.v[ B ] ⟩ app≡ i)
-    ∙ ExpB.β⇒ gᴰ
+  ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof gᴰ =
+    ((λ b bᴰ aᴰ → gᴰ b (bᴰ , aᴰ)) ,
+     (λ i → ×f*Aᴰ.×aF .F-hom (ExpB.lda gᴰ) ⋆⟨ SETᴰ.v[ B ] ⟩ preserves-elt i)
+     ∙ ExpB.β⇒ gᴰ) ,
+    (λ (hᴰ , x) →
+      ΣPathP (
+        (funExt₂ λ b bᴰ → funExt λ faᴰ →
+         (sym $ funExt⁻ (funExt⁻ x b) (bᴰ , faᴰ))
+         ∙ ((λ i → (×f*Aᴰ.×aF .F-hom hᴰ ⋆⟨ SETᴰ.v[ B ] ⟩ preserves-elt i) b (bᴰ , faᴰ)))
+         ∙ funExt⁻ (funExt⁻ (ExpB.β⇒ _) b) ((bᴰ , faᴰ))
+        ) ,
+        isSet→SquareP (λ _ _ →
+          str (ExponentiableProf _ (bpw (f*F ⟅ Aᴰ ⟆)) .F-ob (f*F ⟅ Aᴰ' ⟆) .F-ob Bᴰ)) _ _ _ _))
     where
     f*F : Functor SETᴰ.v[ A ] SETᴰ.v[ B ]
     f*F = CartesianLiftF-fiber (SETᴰ ℓ ℓ') isFibrationSETᴰ f
 
-    f*_ : SETᴰ.v[ A ] .ob → SETᴰ.v[ B ] .ob
-    f*_ = f*F .F-ob
-
-    module bpA = BinProductsNotation (bp A)
-    module bpB = BinProductsNotation (bp B)
-    module bpwf*Aᴰ = BinProductsWithNotation (bpw (f* Aᴰ))
-    open bpwf*Aᴰ
-
-
-    module ExpA = ExponentialsNotation (bp A) (FiberExponentialSETᴰ A)
+    module ×f*Aᴰ = BinProductsWithNotation (bpw (f*F ⟅ Aᴰ ⟆))
     module ExpB = ExponentialsNotation (bp B) (FiberExponentialSETᴰ B)
 
-    _⇒A_ = ExpA._⇒_
-    _⇒B_ = ExpB._⇒_
-
-    CLAᴰ = isFibrationSETᴰ {c = B}{c' = A} Aᴰ f
-    CLAᴰ' = isFibrationSETᴰ {c = B}{c' = A} Aᴰ' f
-    CLAᴰ⇒Aᴰ' = isFibrationSETᴰ {c = B}{c' = A} (Aᴰ ⇒A Aᴰ') f
-    module f*Aᴰ = CartesianLift CLAᴰ
-    module f*Aᴰ' = CartesianLift CLAᴰ'
-    module f*Aᴰ⇒Aᴰ' = CartesianLift CLAᴰ⇒Aᴰ'
-
-    expPshA : Functor (SETᴰ.v[ A ] ^op) (SET (ℓ-max ℓ ℓ'))
-    expPshA = ExponentiableProf SETᴰ.v[ A ] (bpw Aᴰ) .F-ob Aᴰ'
-
-    expPshB : Functor (SETᴰ.v[ B ] ^op) (SET (ℓ-max ℓ ℓ'))
-    expPshB = ExponentiableProf SETᴰ.v[ B ] (bpw (f* Aᴰ)) .F-ob (f* Aᴰ')
-
-    module PA = PresheafNotation expPshA
-    module PB = PresheafNotation expPshB
-
-    --              λgᴰ
-    --    Bᴰ -------------> f* (Aᴰ ⇒A Aᴰ')
-    --    |                       |
-    --    |                       |
-    --    |                       |
-    --    v                       v
-    --    B --------------------> B
-    --             id
-    λgᴰ : SETᴰ.v[ B ] [ Bᴰ , (f* Aᴰ) ⇒B (f* Aᴰ') ]
-    λgᴰ = ExpB.lda gᴰ
-
-    pshHom : PshHomᴰ f*F expPshA expPshB
-    pshHom = preservesExpCone f*F (bpw Aᴰ)
-      (λ Aᴰ' → cartesianLift-preserves-BinProductFiber (SETᴰ ℓ ℓ') isFibrationSETᴰ
-                       (BinProductsⱽSETᴰ A (Aᴰ' , Aᴰ)) f)
-      (bpw (f* Aᴰ)) Aᴰ'
-    α : (Aᴰ'' : ob SETᴰ.v[ A ]) → PA.p[ Aᴰ'' ] → PB.p[ f* Aᴰ'' ]
-    α = pshHom .fst
-
-    vert≡ : ∀ {Aᴰ Aᴰ'} → (f* (Aᴰ ⇒A Aᴰ')) ≡ ((f* Aᴰ) ⇒B (f* Aᴰ'))
-    vert≡ = refl
-
-    app≡ : α (Aᴰ ⇒A Aᴰ') ExpA.app ≡ ExpB.app
-    app≡ = β (FiberExponentialSETᴰ B (f* Aᴰ) (f* Aᴰ'))
-
-  ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof gᴰ .snd (hᴰ , x) =
-    ΣPathP (
-      (funExt₂ λ b bᴰ → funExt λ faᴰ →
-        gᴰ b (bᴰ , faᴰ)
-          ≡⟨ (sym $ funExt⁻ (funExt⁻ x b) (bᴰ , faᴰ)) ⟩
-       (×aF .F-hom hᴰ ⋆⟨ SETᴰ.v[ B ] ⟩ α _ ExpA.app) b (bᴰ , faᴰ)
-          ≡⟨ ((λ i → (×aF .F-hom hᴰ ⋆⟨ SETᴰ.v[ B ] ⟩ app≡ i) b (bᴰ , faᴰ))) ⟩
-       (×aF .F-hom hᴰ ⋆⟨ SETᴰ.v[ B ] ⟩ ExpB.app) b (bᴰ , faᴰ)
-          ≡⟨ funExt⁻ (funExt⁻ (ExpB.β⇒ λ x₁ z → hᴰ x₁ (z .fst) (z .snd)) b) (bᴰ , faᴰ) ⟩
-        hᴰ b bᴰ faᴰ
-      ∎) ,
-      isSet→SquareP (λ _ _ →
-        str (RightAdjointProf (BinProductWithF SETᴰ.v[ B ] (bpw (f* Aᴰ))) .F-ob (f* Aᴰ') .F-ob Bᴰ)) _ _ _ _)
-    where
-    f*F : Functor SETᴰ.v[ A ] SETᴰ.v[ B ]
-    f*F = CartesianLiftF-fiber (SETᴰ ℓ ℓ') isFibrationSETᴰ f
-
-    f*_ : SETᴰ.v[ A ] .ob → SETᴰ.v[ B ] .ob
-    f*_ = f*F .F-ob
-
-    module bpA = BinProductsNotation (bp A)
-    module bpB = BinProductsNotation (bp B)
-    module bpwf*Aᴰ = BinProductsWithNotation (bpw (f* Aᴰ))
-    open bpwf*Aᴰ
-
-
-    module ExpA = ExponentialsNotation (bp A) (FiberExponentialSETᴰ A)
-    module ExpB = ExponentialsNotation (bp B) (FiberExponentialSETᴰ B)
-
-    _⇒A_ = ExpA._⇒_
-    _⇒B_ = ExpB._⇒_
-
-    CLAᴰ = isFibrationSETᴰ {c = B}{c' = A} Aᴰ f
-    CLAᴰ' = isFibrationSETᴰ {c = B}{c' = A} Aᴰ' f
-    CLAᴰ⇒Aᴰ' = isFibrationSETᴰ {c = B}{c' = A} (Aᴰ ⇒A Aᴰ') f
-    module f*Aᴰ = CartesianLift CLAᴰ
-    module f*Aᴰ' = CartesianLift CLAᴰ'
-    module f*Aᴰ⇒Aᴰ' = CartesianLift CLAᴰ⇒Aᴰ'
-
-    expPshA : Functor (SETᴰ.v[ A ] ^op) (SET (ℓ-max ℓ ℓ'))
-    expPshA = ExponentiableProf SETᴰ.v[ A ] (bpw Aᴰ) .F-ob Aᴰ'
-
-    expPshB : Functor (SETᴰ.v[ B ] ^op) (SET (ℓ-max ℓ ℓ'))
-    expPshB = ExponentiableProf SETᴰ.v[ B ] (bpw (f* Aᴰ)) .F-ob (f* Aᴰ')
-
-    module PA = PresheafNotation expPshA
-    module PB = PresheafNotation expPshB
-
-    --              λgᴰ
-    --    Bᴰ -------------> f* (Aᴰ ⇒A Aᴰ')
-    --    |                       |
-    --    |                       |
-    --    |                       |
-    --    v                       v
-    --    B --------------------> B
-    --             id
-    λgᴰ : SETᴰ.v[ B ] [ Bᴰ , (f* Aᴰ) ⇒B (f* Aᴰ') ]
-    λgᴰ = ExpB.lda gᴰ
-
-    pshHom : PshHomᴰ f*F expPshA expPshB
-    pshHom = preservesExpCone f*F (bpw Aᴰ)
-      (λ Aᴰ' → cartesianLift-preserves-BinProductFiber (SETᴰ ℓ ℓ') isFibrationSETᴰ
-                       (BinProductsⱽSETᴰ A (Aᴰ' , Aᴰ)) f)
-      (bpw (f* Aᴰ)) Aᴰ'
-    α : (Aᴰ'' : ob SETᴰ.v[ A ]) → PA.p[ Aᴰ'' ] → PB.p[ f* Aᴰ'' ]
-    α = pshHom .fst
-
-    vert≡ : ∀ {Aᴰ Aᴰ'} → (f* (Aᴰ ⇒A Aᴰ')) ≡ ((f* Aᴰ) ⇒B (f* Aᴰ'))
-    vert≡ = refl
-
-    app≡ : α (Aᴰ ⇒A Aᴰ') ExpA.app ≡ ExpB.app
-    app≡ = β (FiberExponentialSETᴰ B (f* Aᴰ) (f* Aᴰ'))
+    preserves-elt = β (FiberExponentialSETᴰ B (f*F ⟅ Aᴰ ⟆) (f*F ⟅ Aᴰ' ⟆)) {p = ExpB.app}

--- a/Cubical/Categories/Displayed/Instances/Sets/Properties.agda
+++ b/Cubical/Categories/Displayed/Instances/Sets/Properties.agda
@@ -15,10 +15,7 @@ open import Cubical.Data.Sigma.Properties
 open import Cubical.Data.Unit
 
 open import Cubical.Categories.Category
-open import Cubical.Categories.Yoneda
 open import Cubical.Categories.Functor
-open import Cubical.Categories.Bifunctor
-open import Cubical.Categories.NaturalTransformation
 open import Cubical.Categories.Adjoint.UniversalElements
 open import Cubical.Categories.Limits.BinProduct.More
 open import Cubical.Categories.Instances.Sets
@@ -138,8 +135,6 @@ module _ {ℓ} {ℓ'} where
 
   open Exponentialⱽ
   open UniversalElementNotation
-  open NatTrans
-  open Bifunctor
   ExponentialsⱽSETᴰ : Exponentialsⱽ (SETᴰ ℓ ℓ') BinProductsⱽSETᴰ isFibrationSETᴰ
   ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .cᴰ⇒cᴰ' = FiberExponentialSETᴰ A Aᴰ Aᴰ'
   ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof gᴰ .fst .fst b bᴰ aᴰ = gᴰ b (bᴰ , aᴰ)

--- a/Cubical/Categories/Displayed/Instances/Sets/Properties.agda
+++ b/Cubical/Categories/Displayed/Instances/Sets/Properties.agda
@@ -15,13 +15,17 @@ open import Cubical.Data.Sigma.Properties
 open import Cubical.Data.Unit
 
 open import Cubical.Categories.Category
+open import Cubical.Categories.Yoneda
 open import Cubical.Categories.Functor
+open import Cubical.Categories.Bifunctor
+open import Cubical.Categories.NaturalTransformation
 open import Cubical.Categories.Adjoint.UniversalElements
 open import Cubical.Categories.Limits.BinProduct.More
 open import Cubical.Categories.Instances.Sets
 open import Cubical.Categories.Instances.Sets.More
 open import Cubical.Categories.Instances.Sets.Properties
 open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.Constructions
 open import Cubical.Categories.Presheaf.More
 open import Cubical.Categories.Presheaf.Morphism.Alt
 open import Cubical.Categories.Presheaf.Representable
@@ -111,11 +115,9 @@ module _ {ℓ} {ℓ'} where
     bp : (A : SET ℓ .ob) → BinProducts SETᴰ.v[ A ]
     bp A = BinProductsⱽ→BinProductsFibers (SETᴰ ℓ ℓ') BinProductsⱽSETᴰ
 
-    bpw : {A : Category.ob (SET ℓ)} → (Aᴰ Aᴰ' : SETᴰ.ob[ A ]) →
-      UniversalElement SETᴰ.v[ A ] _
-    bpw {A = A} Aᴰ =
-      (BinProductsWithⱽ→BinProductsWithFiber (SETᴰ ℓ ℓ')
-        (λ cᴰ' → BinProductsⱽSETᴰ A (cᴰ' , Aᴰ)))
+    bpw : {A : Category.ob (SET ℓ)} → (Aᴰ : SETᴰ.ob[ A ]) →
+      BinProductsWith SETᴰ.v[ A ] Aᴰ
+    bpw {A = A} Aᴰ Aᴰ' = bp A (Aᴰ' , Aᴰ)
 
   open Functor
   open UniversalElement
@@ -128,155 +130,87 @@ module _ {ℓ} {ℓ'} where
   FiberExponentialSETᴰ A Aᴰ Aᴰ' .universal Aᴰ'' .equiv-proof f .fst .snd =
     fromPathP (λ i → transport-filler (λ j → (a : ⟨ A ⟩) → ⟨ Aᴰ'' a ⟩ × ⟨ Aᴰ a ⟩ → ⟨ Aᴰ' a ⟩) f (~ i))
   FiberExponentialSETᴰ A Aᴰ Aᴰ' .universal Aᴰ'' .equiv-proof f .snd (g , x) =
-    ΣPathP (
-      funExt₂ (λ a aᴰ'' → funExt λ aᴰ → sym (funExt⁻ (funExt⁻ x a) (aᴰ'' , aᴰ)))
-      ∙ fromPathP (λ i → transport-filler (λ j → (a : ⟨ A ⟩) → ⟨ Aᴰ'' a ⟩ → ⟨ Aᴰ a ⟩ → ⟨ Aᴰ' a ⟩) g (~ i)) ,
-      isSet→SquareP (λ _ _ → str (RightAdjointProf (BinProductWithF SETᴰ.v[ A ] (bpw Aᴰ)) .F-ob Aᴰ' .F-ob Aᴰ'')) _ _ _ _
-      )
+    {!!}
+    -- ΣPathP (
+    --   funExt₂ (λ a aᴰ'' → funExt λ aᴰ → sym (funExt⁻ (funExt⁻ x a) (aᴰ'' , aᴰ)))
+    --   ∙ fromPathP (λ i → transport-filler (λ j → (a : ⟨ A ⟩) → ⟨ Aᴰ'' a ⟩ → ⟨ Aᴰ a ⟩ → ⟨ Aᴰ' a ⟩) g (~ i)) ,
+    --   isSet→SquareP (λ _ _ → str (RightAdjointProf (BinProductWithF SETᴰ.v[ A ] (bpw Aᴰ)) .F-ob Aᴰ' .F-ob Aᴰ'')) _ _ _ _
+    --   )
 
-  open import Cubical.Categories.Yoneda
-  open Exponentialⱽ
-  open UniversalElementNotation
-  ExponentialsⱽSETᴰ : Exponentialsⱽ (SETᴰ ℓ ℓ') BinProductsⱽSETᴰ isFibrationSETᴰ
-  ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .cᴰ⇒cᴰ' = FiberExponentialSETᴰ A Aᴰ Aᴰ'
-  ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof gᴰ .fst .fst b bᴰ aᴰ = gᴰ b (bᴰ , aᴰ)
-  ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof gᴰ .fst .snd =
-    funExt₂ (λ where
-      b (bᴰ , x) →
-        -- I don't think this is the best way to solve this equality, but I have exhausted all
-        -- ideas other than expanding everything defintionally
-        -- (λgᴰ PB.⋆ app') b (bᴰ , x)
-        --   ≡⟨ refl ⟩
-        -- expPshB .F-hom λgᴰ app' b (bᴰ , x)
-        --   ≡⟨ refl ⟩
-        ((SETᴰ.v[ B ] [-, (f* Aᴰ') ]) ∘F (BinProductWithF _ (bpw (f* Aᴰ)) ^opF))
-          .F-hom λgᴰ app' b (bᴰ , x)
-          ≡⟨ refl ⟩
-        (SETᴰ.v[ B ] [-, (f* Aᴰ') ]) .F-hom ((BinProductWithF _ (bpw (f* Aᴰ)) ^opF) .F-hom λgᴰ)
-          app' b (bᴰ , x)
-          ≡⟨ refl ⟩
-          -- ?1 is some term with an intro?
-        (SETᴰ.v[ B ] [-, (f* Aᴰ') ]) .F-hom {!!}
-          app' b (bᴰ , x)
-          ≡⟨ refl ⟩
-        {!!}
-          ≡⟨ {!!} ⟩
-        {!!}
-          ≡⟨ {!!} ⟩
-        {!!}
-          ≡⟨ {!!} ⟩
-        gᴰ b (bᴰ , x)
-        ∎
-    )
-    -- λgᴰ PB.⋆ app'
-    --   ≡⟨ {!!} ⟩
-    -- (introCL CLAᴰ⇒Aᴰ' λgᴰ') PB.⋆ (α (Aᴰ ⇒A Aᴰ') ExpA.app)
-    --   ≡⟨ {!!} ⟩
-    -- gᴰ
-    -- ∎
-    where
-    f*F : Functor SETᴰ.v[ A ] SETᴰ.v[ B ]
-    f*F = CartesianLiftF-fiber (SETᴰ ℓ ℓ') isFibrationSETᴰ f
+  -- open Exponentialⱽ
+  -- open UniversalElementNotation
+  -- open NatTrans
+  -- open Bifunctor
+  -- ExponentialsⱽSETᴰ : Exponentialsⱽ (SETᴰ ℓ ℓ') BinProductsⱽSETᴰ isFibrationSETᴰ
+  -- ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .cᴰ⇒cᴰ' = FiberExponentialSETᴰ A Aᴰ Aᴰ'
+  -- ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof gᴰ .fst .fst b bᴰ aᴰ = gᴰ b (bᴰ , aᴰ)
+  -- ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof gᴰ .fst .snd =
+  --   (λ i → ×aF .F-hom λgᴰ ⋆⟨ SETᴰ.v[ B ] ⟩ app≡ i)
+  --   ∙ ExpB.β⇒ gᴰ
+  --   where
+  --   f*F : Functor SETᴰ.v[ A ] SETᴰ.v[ B ]
+  --   f*F = CartesianLiftF-fiber (SETᴰ ℓ ℓ') isFibrationSETᴰ f
 
-    f*_ : SETᴰ.v[ A ] .ob → SETᴰ.v[ B ] .ob
-    f*_ = f*F .F-ob
+  --   f*_ : SETᴰ.v[ A ] .ob → SETᴰ.v[ B ] .ob
+  --   f*_ = f*F .F-ob
 
-    module bpA = BinProductsNotation (bp A)
-    module bpB = BinProductsNotation (bp B)
+  --   module bpA = BinProductsNotation (bp A)
+  --   module bpB = BinProductsNotation (bp B)
+  --   module bpwf*Aᴰ = BinProductsWithNotation (bpw (f* Aᴰ))
+  --   open bpwf*Aᴰ
 
-    _,pA_ = bpA._,p_
-    _,pB_ = bpB._,p_
-    _×A_ = bpA._×_
-    _×pA_ = bpA._×p_
-    _×B_ = bpB._×_
-    _×pB_ = bpB._×p_
 
-    module ExpA = ExponentialsNotation (bp A) (FiberExponentialSETᴰ A)
-    module ExpB = ExponentialsNotation (bp B) (FiberExponentialSETᴰ B)
+  --   module ExpA = ExponentialsNotation (bp A) (FiberExponentialSETᴰ A)
+  --   module ExpB = ExponentialsNotation (bp B) (FiberExponentialSETᴰ B)
 
-    _⇒A_ = ExpA._⇒_
-    _⇒B_ = ExpB._⇒_
+  --   _⇒A_ = ExpA._⇒_
+  --   _⇒B_ = ExpB._⇒_
 
-    CLAᴰ = isFibrationSETᴰ {c = B}{c' = A} Aᴰ f
-    CLAᴰ' = isFibrationSETᴰ {c = B}{c' = A} Aᴰ' f
-    CLAᴰ⇒Aᴰ' = isFibrationSETᴰ {c = B}{c' = A} (Aᴰ ⇒A Aᴰ') f
-    module f*Aᴰ = CartesianLift CLAᴰ
-    module f*Aᴰ' = CartesianLift CLAᴰ'
-    module f*Aᴰ⇒Aᴰ' = CartesianLift CLAᴰ⇒Aᴰ'
+  --   CLAᴰ = isFibrationSETᴰ {c = B}{c' = A} Aᴰ f
+  --   CLAᴰ' = isFibrationSETᴰ {c = B}{c' = A} Aᴰ' f
+  --   CLAᴰ⇒Aᴰ' = isFibrationSETᴰ {c = B}{c' = A} (Aᴰ ⇒A Aᴰ') f
+  --   module f*Aᴰ = CartesianLift CLAᴰ
+  --   module f*Aᴰ' = CartesianLift CLAᴰ'
+  --   module f*Aᴰ⇒Aᴰ' = CartesianLift CLAᴰ⇒Aᴰ'
 
-    expPshA : Functor (SETᴰ.v[ A ] ^op) (SET (ℓ-max ℓ ℓ'))
-    expPshA = ExponentiableProf SETᴰ.v[ A ] (bpw Aᴰ) .F-ob Aᴰ'
+  --   expPshA : Functor (SETᴰ.v[ A ] ^op) (SET (ℓ-max ℓ ℓ'))
+  --   expPshA = ExponentiableProf SETᴰ.v[ A ] (bpw Aᴰ) .F-ob Aᴰ'
 
-    expPshB : Functor (SETᴰ.v[ B ] ^op) (SET (ℓ-max ℓ ℓ'))
-    expPshB = ExponentiableProf SETᴰ.v[ B ] (bpw (f* Aᴰ)) .F-ob (f* Aᴰ')
+  --   expPshB : Functor (SETᴰ.v[ B ] ^op) (SET (ℓ-max ℓ ℓ'))
+  --   expPshB = ExponentiableProf SETᴰ.v[ B ] (bpw (f* Aᴰ)) .F-ob (f* Aᴰ')
 
-    module PA = PresheafNotation expPshA
-    module PB = PresheafNotation expPshB
+  --   module PA = PresheafNotation expPshA
+  --   module PB = PresheafNotation expPshB
 
-    --              λgᴰ
-    --    Bᴰ -------------> f* (Aᴰ ⇒A Aᴰ')
-    --    |                       |
-    --    |                       |
-    --    |                       |
-    --    v                       v
-    --    B --------------------> B
-    --             id
-    λgᴰ : SETᴰ.v[ B ] [ Bᴰ , f* (Aᴰ ⇒A Aᴰ') ]
-    λgᴰ = ExpB.lda gᴰ
+  --   --              λgᴰ
+  --   --    Bᴰ -------------> f* (Aᴰ ⇒A Aᴰ')
+  --   --    |                       |
+  --   --    |                       |
+  --   --    |                       |
+  --   --    v                       v
+  --   --    B --------------------> B
+  --   --             id
+  --   λgᴰ : SETᴰ.v[ B ] [ Bᴰ , (f* Aᴰ) ⇒B (f* Aᴰ') ]
+  --   λgᴰ = ExpB.lda gᴰ
 
-    λgᴰ' : Cᴰ.Hom[ f ][ Bᴰ , Aᴰ ⇒A Aᴰ' ]
-    λgᴰ' = Cᴰ._⋆ᴰ_ {zᴰ = Aᴰ ⇒A Aᴰ'} λgᴰ f*Aᴰ⇒Aᴰ'.π
+  --   pshHom : PshHomᴰ f*F expPshA expPshB
+  --   pshHom = preservesExpCone f*F (bpw Aᴰ)
+  --     (λ Aᴰ' → cartesianLift-preserves-BinProductFiber (SETᴰ ℓ ℓ') isFibrationSETᴰ
+  --                      (BinProductsⱽSETᴰ A (Aᴰ' , Aᴰ)) f)
+  --     (bpw (f* Aᴰ)) Aᴰ'
+  --   α : (Aᴰ'' : ob SETᴰ.v[ A ]) → PA.p[ Aᴰ'' ] → PB.p[ f* Aᴰ'' ]
+  --   α = pshHom .fst
 
-    λgᴰ≡ : λgᴰ ≡ introCL CLAᴰ⇒Aᴰ' λgᴰ'
-    λgᴰ≡ = ηᴰCL CLAᴰ⇒Aᴰ'
+  --   vert≡ : ∀ {Aᴰ Aᴰ'} → (f* (Aᴰ ⇒A Aᴰ')) ≡ ((f* Aᴰ) ⇒B (f* Aᴰ'))
+  --   vert≡ = refl
 
-    u : expPshB .F-hom λgᴰ ≡ λ ϕ → λgᴰ ×pB (SETᴰ.v[ B ] .id) ⋆⟨ SETᴰ.v[ B ] ⟩ ϕ
-    u =
-      -- fromPathP (λ i → transport-filler (λ j → (x : expPshB .F-ob (f* (Aᴰ ⇒A Aᴰ')) .fst) →
-      --                                            (b : ⟨ B ⟩) →
-      --                                            ⟨ Bᴰ b ⟩ × ⟨ Aᴰ (f b) ⟩ →
-      --                                            {!⟨ Aᴰ' (f b) ⟩!})
-      --                    (expPshB .F-hom λgᴰ) i)
-      funExt₂
-      (λ where x b → funExt λ where
-        (bᴰ , aᴰ) → {!!}
-      )
+  --   app≡ : α (Aᴰ ⇒A Aᴰ') ExpA.app ≡ ExpB.app
+  --   app≡ = β (FiberExponentialSETᴰ B (f* Aᴰ) (f* Aᴰ'))
 
-    -- precompλgᴰ×id : SETᴰ.v[ B ] [ (f* (Aᴰ ⇒A Aᴰ')) ×B (f* Aᴰ) , f* Aᴰ' ] →
-    --                SETᴰ.v[ B ] [  Bᴰ ×B (f* Aᴰ) , f* Aᴰ' ]
-    -- precompλgᴰ×id = expPshB .F-hom λgᴰ
+  -- ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof gᴰ .snd (hᴰ , x) =
+  --   {!!}
+  --   where
+  --   module ExpA = ExponentialsNotation (bp A) (FiberExponentialSETᴰ A)
+  --   module ExpB = ExponentialsNotation (bp B) (FiberExponentialSETᴰ B)
 
-    --                  gᴰ
-    -- Bᴰ ×ⱽ f* Aᴰ -------------> Aᴰ'
-    --    |                       |
-    --    |                       |
-    --    |                       |
-    --    v                       v
-    --    B --------------------> A
-    --             f
-    gᴰ' : (SETᴰ ℓ ℓ') [ f ][ Bᴰ ×B (f* Aᴰ) , Aᴰ' ]
-    gᴰ' = gᴰ
-
-    pshHom : PshHomᴰ f*F expPshA expPshB
-    pshHom = preservesExpCone f*F (λ Aᴰ'' → bp A (Aᴰ'' , Aᴰ))
-        (λ z →
-           cartesianLift-preserves-BinProductFiber (SETᴰ ℓ ℓ') isFibrationSETᴰ
-           (BinProductsⱽSETᴰ A (z , Aᴰ)) f)
-        (bpw (f* Aᴰ)) Aᴰ'
-
-    α : (Aᴰ'' : ob SETᴰ.v[ A ]) → PA.p[ Aᴰ'' ] → PB.p[ f* Aᴰ'' ]
-    α = pshHom .fst
-
-    α-natural : ∀ Aᴰ₁ Aᴰ₂ h x → α Aᴰ₁ (h PA.⋆ x) ≡ ((f*F .F-hom h) PB.⋆ α Aᴰ₂ x)
-    α-natural = pshHom .snd
-
-    app' : SETᴰ.v[ B ] [ (f* (Aᴰ ⇒A Aᴰ')) ×B (f* Aᴰ) , f* Aᴰ' ]
-    app' = α (Aᴰ ⇒A Aᴰ') ExpA.app
-
-    app'' : Cᴰ.Hom[ f ][ (f* (Aᴰ ⇒A Aᴰ')) ×B (f* Aᴰ) , Aᴰ' ]
-    app'' = Cᴰ._⋆ᴰ_ {zᴰ = Aᴰ'} app' f*Aᴰ'.π
-
-    app≡ : app' ≡ introCL CLAᴰ' app''
-    app≡ = ηᴰCL CLAᴰ'
-
-  ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof gᴰ .snd = {!!}
+  --   _⇒A_ = ExpA._⇒_

--- a/Cubical/Categories/Displayed/Instances/Sets/Properties.agda
+++ b/Cubical/Categories/Displayed/Instances/Sets/Properties.agda
@@ -140,11 +140,11 @@ module _ {ℓ} {ℓ'} where
       (λ gᴰ b bᴰ faᴰ → gᴰ b (bᴰ , faᴰ)) ,
       (λ gᴰ →
         (λ i → ×f*Aᴰ.×aF .F-hom (ExpB.lda gᴰ) ⋆⟨ SETᴰ.v[ B ] ⟩ preserves-elt i)
-        ∙ ExpB.β⇒ gᴰ
+        ∙ β (FiberExponentialSETᴰ _ _ _)
       ) ,
       (λ gᴰ → funExt₃ λ b bᴰ faᴰ →
         (λ i → (×f*Aᴰ.×aF .F-hom gᴰ ⋆⟨ SETᴰ.v[ B ] ⟩ preserves-elt i) b (bᴰ , faᴰ))
-        ∙ funExt⁻ (funExt⁻ (ExpB.β⇒ _) b) ((bᴰ , faᴰ))
+        ∙ funExt⁻ (funExt⁻ (β (FiberExponentialSETᴰ _ _ _)) b) ((bᴰ , faᴰ))
       )
     )
     where

--- a/Cubical/Categories/Displayed/Instances/Sets/Properties.agda
+++ b/Cubical/Categories/Displayed/Instances/Sets/Properties.agda
@@ -3,20 +3,30 @@ module Cubical.Categories.Displayed.Instances.Sets.Properties where
 
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Function
+open import Cubical.Foundations.Isomorphism
 open import Cubical.Functions.FunExtEquiv
 open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Equiv.Dependent
 open import Cubical.Foundations.Structure
+open import Cubical.Foundations.Transport
 open import Cubical.Data.Sigma
 open import Cubical.Data.Sigma.Properties
 open import Cubical.Data.Unit
 
 open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+open import Cubical.Categories.Adjoint.UniversalElements
+open import Cubical.Categories.Limits.BinProduct.More
 open import Cubical.Categories.Instances.Sets
 open import Cubical.Categories.Instances.Sets.More
 open import Cubical.Categories.Instances.Sets.Properties
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.Representable
 open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Exponentials
+
+open import Cubical.Categories.Constructions.Fiber
 
 open import Cubical.Categories.Displayed.Functor
 open import Cubical.Categories.Displayed.Fibration.Base
@@ -24,7 +34,9 @@ open import Cubical.Categories.Displayed.Instances.Sets.Base
 open import Cubical.Categories.Displayed.Presheaf
 open import Cubical.Categories.Displayed.Limits.Cartesian
 open import Cubical.Categories.Displayed.Limits.BinProduct
+open import Cubical.Categories.Displayed.Limits.BinProduct.Fiberwise
 open import Cubical.Categories.Displayed.Limits.Terminal
+open import Cubical.Categories.Displayed.Exponentials.Base
 
 
 private
@@ -85,3 +97,36 @@ SETᴰCartesianCategoryⱽ ℓ ℓ' .CartesianCategoryⱽ.Cᴰ = SETᴰ ℓ ℓ'
 SETᴰCartesianCategoryⱽ ℓ ℓ' .CartesianCategoryⱽ.termⱽ = TerminalsⱽSETᴰ
 SETᴰCartesianCategoryⱽ ℓ ℓ' .CartesianCategoryⱽ.bpⱽ = BinProductsⱽSETᴰ
 SETᴰCartesianCategoryⱽ ℓ ℓ' .CartesianCategoryⱽ.cartesianLifts = isFibrationSETᴰ
+
+
+module _ {ℓ} {ℓ'} where
+  private
+    module SETᴰ = Fibers (SETᴰ ℓ ℓ')
+
+    bpw : (A : Category.ob (SET ℓ)) → (Aᴰ Aᴰ' : SETᴰ.ob[ A ]) →
+      UniversalElement SETᴰ.v[ A ] _
+    bpw A Aᴰ =
+      (BinProductsWithⱽ→BinProductsWithFiber (SETᴰ ℓ ℓ')
+        (λ cᴰ' → BinProductsⱽSETᴰ A (cᴰ' , Aᴰ)))
+
+  open Functor
+  open UniversalElement
+  FiberExponentialSETᴰ : (A : Category.ob (SET ℓ)) → (Aᴰ Aᴰ' : SETᴰ.ob[ A ]) →
+    Exponential SETᴰ.v[ A ] Aᴰ Aᴰ' (bpw A Aᴰ)
+  FiberExponentialSETᴰ A Aᴰ Aᴰ' .vertex a .fst = ⟨ Aᴰ a ⟩ → ⟨ Aᴰ' a ⟩
+  FiberExponentialSETᴰ A Aᴰ Aᴰ' .vertex a .snd = isSet→ (str (Aᴰ' a))
+  FiberExponentialSETᴰ A Aᴰ Aᴰ' .element a (f , aᴰ) = f aᴰ
+  FiberExponentialSETᴰ A Aᴰ Aᴰ' .universal Aᴰ'' .equiv-proof f .fst .fst a aᴰ'' aᴰ = f a (aᴰ'' , aᴰ)
+  FiberExponentialSETᴰ A Aᴰ Aᴰ' .universal Aᴰ'' .equiv-proof f .fst .snd =
+    fromPathP (λ i → transport-filler (λ j → (a : ⟨ A ⟩) → ⟨ Aᴰ'' a ⟩ × ⟨ Aᴰ a ⟩ → ⟨ Aᴰ' a ⟩) f (~ i))
+  FiberExponentialSETᴰ A Aᴰ Aᴰ' .universal Aᴰ'' .equiv-proof f .snd (g , x) =
+    ΣPathP (
+      funExt₂ (λ a aᴰ'' → funExt λ aᴰ → sym (funExt⁻ (funExt⁻ x a) (aᴰ'' , aᴰ)))
+      ∙ fromPathP (λ i → transport-filler (λ j → (a : ⟨ A ⟩) → ⟨ Aᴰ'' a ⟩ → ⟨ Aᴰ a ⟩ → ⟨ Aᴰ' a ⟩) g (~ i)) ,
+      isSet→SquareP (λ _ _ → str (RightAdjointProf (BinProductWithF SETᴰ.v[ A ] (bpw A Aᴰ)) .F-ob Aᴰ' .F-ob Aᴰ'')) _ _ _ _
+      )
+
+  open Exponentialⱽ
+  ExponentialsⱽSETᴰ : Exponentialsⱽ (SETᴰ ℓ ℓ') BinProductsⱽSETᴰ isFibrationSETᴰ
+  ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .cᴰ⇒cᴰ' = FiberExponentialSETᴰ A Aᴰ Aᴰ'
+  ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ = {!!}

--- a/Cubical/Categories/Displayed/Instances/Sets/Properties.agda
+++ b/Cubical/Categories/Displayed/Instances/Sets/Properties.agda
@@ -105,31 +105,37 @@ SETᴰCartesianCategoryⱽ ℓ ℓ' .CartesianCategoryⱽ.cartesianLifts = isFib
 module _ {ℓ} {ℓ'} where
   private
     module SETᴰ = Fibers (SETᴰ ℓ ℓ')
-    module C = Category (SET ℓ)
-    module Cᴰ = Categoryᴰ (SETᴰ ℓ ℓ')
 
     bp : (A : SET ℓ .ob) → BinProducts SETᴰ.v[ A ]
     bp A = BinProductsⱽ→BinProductsFibers (SETᴰ ℓ ℓ') BinProductsⱽSETᴰ
 
-    bpw : {A : Category.ob (SET ℓ)} → (Aᴰ : SETᴰ.ob[ A ]) →
-      BinProductsWith SETᴰ.v[ A ] Aᴰ
+    bpw : {A : SET ℓ .ob} → (Aᴰ : SETᴰ.ob[ A ]) → BinProductsWith SETᴰ.v[ A ] Aᴰ
     bpw {A = A} Aᴰ Aᴰ' = bp A (Aᴰ' , Aᴰ)
 
   open Functor
   open UniversalElement
-  FiberExponentialSETᴰ : (A : Category.ob (SET ℓ)) → (Aᴰ Aᴰ' : SETᴰ.ob[ A ]) →
+  FiberExponentialSETᴰ : (A : SET ℓ .ob) → (Aᴰ Aᴰ' : SETᴰ.ob[ A ]) →
     Exponential SETᴰ.v[ A ] Aᴰ Aᴰ' (bpw Aᴰ)
   FiberExponentialSETᴰ A Aᴰ Aᴰ' .vertex a .fst = ⟨ Aᴰ a ⟩ → ⟨ Aᴰ' a ⟩
   FiberExponentialSETᴰ A Aᴰ Aᴰ' .vertex a .snd = isSet→ (str (Aᴰ' a))
   FiberExponentialSETᴰ A Aᴰ Aᴰ' .element a (f , aᴰ) = f aᴰ
-  FiberExponentialSETᴰ A Aᴰ Aᴰ' .universal Aᴰ'' .equiv-proof f .fst .fst a aᴰ'' aᴰ = f a (aᴰ'' , aᴰ)
+  FiberExponentialSETᴰ A Aᴰ Aᴰ' .universal Aᴰ'' .equiv-proof f .fst .fst a aᴰ'' aᴰ =
+    f a (aᴰ'' , aᴰ)
   FiberExponentialSETᴰ A Aᴰ Aᴰ' .universal Aᴰ'' .equiv-proof f .fst .snd =
-    fromPathP (λ i → transport-filler (λ j → (a : ⟨ A ⟩) → ⟨ Aᴰ'' a ⟩ × ⟨ Aᴰ a ⟩ → ⟨ Aᴰ' a ⟩) f (~ i))
+    fromPathP (λ i →
+      transport-filler (λ j → (a : ⟨ A ⟩) → ⟨ Aᴰ'' a ⟩ × ⟨ Aᴰ a ⟩ → ⟨ Aᴰ' a ⟩)
+                        f (~ i)
+    )
   FiberExponentialSETᴰ A Aᴰ Aᴰ' .universal Aᴰ'' .equiv-proof f .snd (g , x) =
     ΣPathP (
       funExt₂ (λ a aᴰ'' → funExt λ aᴰ → sym (funExt⁻ (funExt⁻ x a) (aᴰ'' , aᴰ)))
-      ∙ fromPathP (λ i → transport-filler (λ j → (a : ⟨ A ⟩) → ⟨ Aᴰ'' a ⟩ → ⟨ Aᴰ a ⟩ → ⟨ Aᴰ' a ⟩) g (~ i)) ,
-      isSet→SquareP (λ _ _ → str (ExponentiableProf _ (bpw Aᴰ) .F-ob Aᴰ' .F-ob Aᴰ'')) _ _ _ _)
+      ∙ fromPathP (λ i →
+          transport-filler (λ j → (a : ⟨ A ⟩) → ⟨ Aᴰ'' a ⟩ → ⟨ Aᴰ a ⟩ → ⟨ Aᴰ' a ⟩)
+                            g (~ i)
+        ) ,
+      isSet→SquareP (λ _ _ →
+        str (ExponentiableProf _ (bpw Aᴰ) .F-ob Aᴰ' .F-ob Aᴰ'')) _ _ _ _
+    )
 
   open Exponentialⱽ
   open UniversalElementNotation
@@ -138,16 +144,18 @@ module _ {ℓ} {ℓ'} where
   ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof gᴰ =
     ((λ b bᴰ aᴰ → gᴰ b (bᴰ , aᴰ)) ,
      (λ i → ×f*Aᴰ.×aF .F-hom (ExpB.lda gᴰ) ⋆⟨ SETᴰ.v[ B ] ⟩ preserves-elt i)
-     ∙ ExpB.β⇒ gᴰ) ,
+     ∙ ExpB.β⇒ gᴰ
+    ) ,
     (λ (hᴰ , x) →
       ΣPathP (
         (funExt₂ λ b bᴰ → funExt λ faᴰ →
-         (sym $ funExt⁻ (funExt⁻ x b) (bᴰ , faᴰ))
-         ∙ ((λ i → (×f*Aᴰ.×aF .F-hom hᴰ ⋆⟨ SETᴰ.v[ B ] ⟩ preserves-elt i) b (bᴰ , faᴰ)))
-         ∙ funExt⁻ (funExt⁻ (ExpB.β⇒ _) b) ((bᴰ , faᴰ))
+          (sym $ funExt⁻ (funExt⁻ x b) (bᴰ , faᴰ))
+          ∙ (λ i → (×f*Aᴰ.×aF .F-hom hᴰ ⋆⟨ SETᴰ.v[ B ] ⟩ preserves-elt i) b (bᴰ , faᴰ))
+          ∙ funExt⁻ (funExt⁻ (ExpB.β⇒ _) b) ((bᴰ , faᴰ))
         ) ,
-        isSet→SquareP (λ _ _ →
-          str (ExponentiableProf _ (bpw (f*F ⟅ Aᴰ ⟆)) .F-ob (f*F ⟅ Aᴰ' ⟆) .F-ob Bᴰ)) _ _ _ _))
+    isSet→SquareP (λ _ _ →
+      str (ExponentiableProf _ (bpw (f*F ⟅ Aᴰ ⟆))
+             .F-ob (f*F ⟅ Aᴰ' ⟆) .F-ob Bᴰ)) _ _ _ _))
     where
     f*F : Functor SETᴰ.v[ A ] SETᴰ.v[ B ]
     f*F = CartesianLiftF-fiber (SETᴰ ℓ ℓ') isFibrationSETᴰ f
@@ -155,4 +163,5 @@ module _ {ℓ} {ℓ'} where
     module ×f*Aᴰ = BinProductsWithNotation (bpw (f*F ⟅ Aᴰ ⟆))
     module ExpB = ExponentialsNotation (bp B) (FiberExponentialSETᴰ B)
 
-    preserves-elt = β (FiberExponentialSETᴰ B (f*F ⟅ Aᴰ ⟆) (f*F ⟅ Aᴰ' ⟆)) {p = ExpB.app}
+    preserves-elt = β (FiberExponentialSETᴰ B
+                         (f*F ⟅ Aᴰ ⟆) (f*F ⟅ Aᴰ' ⟆)) {p = ExpB.app}

--- a/Cubical/Categories/Displayed/Instances/Sets/Properties.agda
+++ b/Cubical/Categories/Displayed/Instances/Sets/Properties.agda
@@ -130,87 +130,151 @@ module _ {ℓ} {ℓ'} where
   FiberExponentialSETᴰ A Aᴰ Aᴰ' .universal Aᴰ'' .equiv-proof f .fst .snd =
     fromPathP (λ i → transport-filler (λ j → (a : ⟨ A ⟩) → ⟨ Aᴰ'' a ⟩ × ⟨ Aᴰ a ⟩ → ⟨ Aᴰ' a ⟩) f (~ i))
   FiberExponentialSETᴰ A Aᴰ Aᴰ' .universal Aᴰ'' .equiv-proof f .snd (g , x) =
-    {!!}
-    -- ΣPathP (
-    --   funExt₂ (λ a aᴰ'' → funExt λ aᴰ → sym (funExt⁻ (funExt⁻ x a) (aᴰ'' , aᴰ)))
-    --   ∙ fromPathP (λ i → transport-filler (λ j → (a : ⟨ A ⟩) → ⟨ Aᴰ'' a ⟩ → ⟨ Aᴰ a ⟩ → ⟨ Aᴰ' a ⟩) g (~ i)) ,
-    --   isSet→SquareP (λ _ _ → str (RightAdjointProf (BinProductWithF SETᴰ.v[ A ] (bpw Aᴰ)) .F-ob Aᴰ' .F-ob Aᴰ'')) _ _ _ _
-    --   )
+    ΣPathP (
+      funExt₂ (λ a aᴰ'' → funExt λ aᴰ → sym (funExt⁻ (funExt⁻ x a) (aᴰ'' , aᴰ)))
+      ∙ fromPathP (λ i → transport-filler (λ j → (a : ⟨ A ⟩) → ⟨ Aᴰ'' a ⟩ → ⟨ Aᴰ a ⟩ → ⟨ Aᴰ' a ⟩) g (~ i)) ,
+      isSet→SquareP (λ _ _ →
+        str (RightAdjointProf (BinProductWithF SETᴰ.v[ A ] (bpw Aᴰ)) .F-ob Aᴰ' .F-ob Aᴰ'')) _ _ _ _)
 
-  -- open Exponentialⱽ
-  -- open UniversalElementNotation
-  -- open NatTrans
-  -- open Bifunctor
-  -- ExponentialsⱽSETᴰ : Exponentialsⱽ (SETᴰ ℓ ℓ') BinProductsⱽSETᴰ isFibrationSETᴰ
-  -- ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .cᴰ⇒cᴰ' = FiberExponentialSETᴰ A Aᴰ Aᴰ'
-  -- ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof gᴰ .fst .fst b bᴰ aᴰ = gᴰ b (bᴰ , aᴰ)
-  -- ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof gᴰ .fst .snd =
-  --   (λ i → ×aF .F-hom λgᴰ ⋆⟨ SETᴰ.v[ B ] ⟩ app≡ i)
-  --   ∙ ExpB.β⇒ gᴰ
-  --   where
-  --   f*F : Functor SETᴰ.v[ A ] SETᴰ.v[ B ]
-  --   f*F = CartesianLiftF-fiber (SETᴰ ℓ ℓ') isFibrationSETᴰ f
+  open Exponentialⱽ
+  open UniversalElementNotation
+  open NatTrans
+  open Bifunctor
+  ExponentialsⱽSETᴰ : Exponentialsⱽ (SETᴰ ℓ ℓ') BinProductsⱽSETᴰ isFibrationSETᴰ
+  ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .cᴰ⇒cᴰ' = FiberExponentialSETᴰ A Aᴰ Aᴰ'
+  ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof gᴰ .fst .fst b bᴰ aᴰ = gᴰ b (bᴰ , aᴰ)
+  ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof gᴰ .fst .snd =
+    (λ i → ×aF .F-hom λgᴰ ⋆⟨ SETᴰ.v[ B ] ⟩ app≡ i)
+    ∙ ExpB.β⇒ gᴰ
+    where
+    f*F : Functor SETᴰ.v[ A ] SETᴰ.v[ B ]
+    f*F = CartesianLiftF-fiber (SETᴰ ℓ ℓ') isFibrationSETᴰ f
 
-  --   f*_ : SETᴰ.v[ A ] .ob → SETᴰ.v[ B ] .ob
-  --   f*_ = f*F .F-ob
+    f*_ : SETᴰ.v[ A ] .ob → SETᴰ.v[ B ] .ob
+    f*_ = f*F .F-ob
 
-  --   module bpA = BinProductsNotation (bp A)
-  --   module bpB = BinProductsNotation (bp B)
-  --   module bpwf*Aᴰ = BinProductsWithNotation (bpw (f* Aᴰ))
-  --   open bpwf*Aᴰ
+    module bpA = BinProductsNotation (bp A)
+    module bpB = BinProductsNotation (bp B)
+    module bpwf*Aᴰ = BinProductsWithNotation (bpw (f* Aᴰ))
+    open bpwf*Aᴰ
 
 
-  --   module ExpA = ExponentialsNotation (bp A) (FiberExponentialSETᴰ A)
-  --   module ExpB = ExponentialsNotation (bp B) (FiberExponentialSETᴰ B)
+    module ExpA = ExponentialsNotation (bp A) (FiberExponentialSETᴰ A)
+    module ExpB = ExponentialsNotation (bp B) (FiberExponentialSETᴰ B)
 
-  --   _⇒A_ = ExpA._⇒_
-  --   _⇒B_ = ExpB._⇒_
+    _⇒A_ = ExpA._⇒_
+    _⇒B_ = ExpB._⇒_
 
-  --   CLAᴰ = isFibrationSETᴰ {c = B}{c' = A} Aᴰ f
-  --   CLAᴰ' = isFibrationSETᴰ {c = B}{c' = A} Aᴰ' f
-  --   CLAᴰ⇒Aᴰ' = isFibrationSETᴰ {c = B}{c' = A} (Aᴰ ⇒A Aᴰ') f
-  --   module f*Aᴰ = CartesianLift CLAᴰ
-  --   module f*Aᴰ' = CartesianLift CLAᴰ'
-  --   module f*Aᴰ⇒Aᴰ' = CartesianLift CLAᴰ⇒Aᴰ'
+    CLAᴰ = isFibrationSETᴰ {c = B}{c' = A} Aᴰ f
+    CLAᴰ' = isFibrationSETᴰ {c = B}{c' = A} Aᴰ' f
+    CLAᴰ⇒Aᴰ' = isFibrationSETᴰ {c = B}{c' = A} (Aᴰ ⇒A Aᴰ') f
+    module f*Aᴰ = CartesianLift CLAᴰ
+    module f*Aᴰ' = CartesianLift CLAᴰ'
+    module f*Aᴰ⇒Aᴰ' = CartesianLift CLAᴰ⇒Aᴰ'
 
-  --   expPshA : Functor (SETᴰ.v[ A ] ^op) (SET (ℓ-max ℓ ℓ'))
-  --   expPshA = ExponentiableProf SETᴰ.v[ A ] (bpw Aᴰ) .F-ob Aᴰ'
+    expPshA : Functor (SETᴰ.v[ A ] ^op) (SET (ℓ-max ℓ ℓ'))
+    expPshA = ExponentiableProf SETᴰ.v[ A ] (bpw Aᴰ) .F-ob Aᴰ'
 
-  --   expPshB : Functor (SETᴰ.v[ B ] ^op) (SET (ℓ-max ℓ ℓ'))
-  --   expPshB = ExponentiableProf SETᴰ.v[ B ] (bpw (f* Aᴰ)) .F-ob (f* Aᴰ')
+    expPshB : Functor (SETᴰ.v[ B ] ^op) (SET (ℓ-max ℓ ℓ'))
+    expPshB = ExponentiableProf SETᴰ.v[ B ] (bpw (f* Aᴰ)) .F-ob (f* Aᴰ')
 
-  --   module PA = PresheafNotation expPshA
-  --   module PB = PresheafNotation expPshB
+    module PA = PresheafNotation expPshA
+    module PB = PresheafNotation expPshB
 
-  --   --              λgᴰ
-  --   --    Bᴰ -------------> f* (Aᴰ ⇒A Aᴰ')
-  --   --    |                       |
-  --   --    |                       |
-  --   --    |                       |
-  --   --    v                       v
-  --   --    B --------------------> B
-  --   --             id
-  --   λgᴰ : SETᴰ.v[ B ] [ Bᴰ , (f* Aᴰ) ⇒B (f* Aᴰ') ]
-  --   λgᴰ = ExpB.lda gᴰ
+    --              λgᴰ
+    --    Bᴰ -------------> f* (Aᴰ ⇒A Aᴰ')
+    --    |                       |
+    --    |                       |
+    --    |                       |
+    --    v                       v
+    --    B --------------------> B
+    --             id
+    λgᴰ : SETᴰ.v[ B ] [ Bᴰ , (f* Aᴰ) ⇒B (f* Aᴰ') ]
+    λgᴰ = ExpB.lda gᴰ
 
-  --   pshHom : PshHomᴰ f*F expPshA expPshB
-  --   pshHom = preservesExpCone f*F (bpw Aᴰ)
-  --     (λ Aᴰ' → cartesianLift-preserves-BinProductFiber (SETᴰ ℓ ℓ') isFibrationSETᴰ
-  --                      (BinProductsⱽSETᴰ A (Aᴰ' , Aᴰ)) f)
-  --     (bpw (f* Aᴰ)) Aᴰ'
-  --   α : (Aᴰ'' : ob SETᴰ.v[ A ]) → PA.p[ Aᴰ'' ] → PB.p[ f* Aᴰ'' ]
-  --   α = pshHom .fst
+    pshHom : PshHomᴰ f*F expPshA expPshB
+    pshHom = preservesExpCone f*F (bpw Aᴰ)
+      (λ Aᴰ' → cartesianLift-preserves-BinProductFiber (SETᴰ ℓ ℓ') isFibrationSETᴰ
+                       (BinProductsⱽSETᴰ A (Aᴰ' , Aᴰ)) f)
+      (bpw (f* Aᴰ)) Aᴰ'
+    α : (Aᴰ'' : ob SETᴰ.v[ A ]) → PA.p[ Aᴰ'' ] → PB.p[ f* Aᴰ'' ]
+    α = pshHom .fst
 
-  --   vert≡ : ∀ {Aᴰ Aᴰ'} → (f* (Aᴰ ⇒A Aᴰ')) ≡ ((f* Aᴰ) ⇒B (f* Aᴰ'))
-  --   vert≡ = refl
+    vert≡ : ∀ {Aᴰ Aᴰ'} → (f* (Aᴰ ⇒A Aᴰ')) ≡ ((f* Aᴰ) ⇒B (f* Aᴰ'))
+    vert≡ = refl
 
-  --   app≡ : α (Aᴰ ⇒A Aᴰ') ExpA.app ≡ ExpB.app
-  --   app≡ = β (FiberExponentialSETᴰ B (f* Aᴰ) (f* Aᴰ'))
+    app≡ : α (Aᴰ ⇒A Aᴰ') ExpA.app ≡ ExpB.app
+    app≡ = β (FiberExponentialSETᴰ B (f* Aᴰ) (f* Aᴰ'))
 
-  -- ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof gᴰ .snd (hᴰ , x) =
-  --   {!!}
-  --   where
-  --   module ExpA = ExponentialsNotation (bp A) (FiberExponentialSETᴰ A)
-  --   module ExpB = ExponentialsNotation (bp B) (FiberExponentialSETᴰ B)
+  ExponentialsⱽSETᴰ {c = A} Aᴰ Aᴰ' .reindex⇒ {b = B} f Bᴰ .equiv-proof gᴰ .snd (hᴰ , x) =
+    ΣPathP (
+      (funExt₂ λ b bᴰ → funExt λ faᴰ →
+        gᴰ b (bᴰ , faᴰ)
+          ≡⟨ (sym $ funExt⁻ (funExt⁻ x b) (bᴰ , faᴰ)) ⟩
+       (×aF .F-hom hᴰ ⋆⟨ SETᴰ.v[ B ] ⟩ α _ ExpA.app) b (bᴰ , faᴰ)
+          ≡⟨ ((λ i → (×aF .F-hom hᴰ ⋆⟨ SETᴰ.v[ B ] ⟩ app≡ i) b (bᴰ , faᴰ))) ⟩
+       (×aF .F-hom hᴰ ⋆⟨ SETᴰ.v[ B ] ⟩ ExpB.app) b (bᴰ , faᴰ)
+          ≡⟨ funExt⁻ (funExt⁻ (ExpB.β⇒ λ x₁ z → hᴰ x₁ (z .fst) (z .snd)) b) (bᴰ , faᴰ) ⟩
+        hᴰ b bᴰ faᴰ
+      ∎) ,
+      isSet→SquareP (λ _ _ →
+        str (RightAdjointProf (BinProductWithF SETᴰ.v[ B ] (bpw (f* Aᴰ))) .F-ob (f* Aᴰ') .F-ob Bᴰ)) _ _ _ _)
+    where
+    f*F : Functor SETᴰ.v[ A ] SETᴰ.v[ B ]
+    f*F = CartesianLiftF-fiber (SETᴰ ℓ ℓ') isFibrationSETᴰ f
 
-  --   _⇒A_ = ExpA._⇒_
+    f*_ : SETᴰ.v[ A ] .ob → SETᴰ.v[ B ] .ob
+    f*_ = f*F .F-ob
+
+    module bpA = BinProductsNotation (bp A)
+    module bpB = BinProductsNotation (bp B)
+    module bpwf*Aᴰ = BinProductsWithNotation (bpw (f* Aᴰ))
+    open bpwf*Aᴰ
+
+
+    module ExpA = ExponentialsNotation (bp A) (FiberExponentialSETᴰ A)
+    module ExpB = ExponentialsNotation (bp B) (FiberExponentialSETᴰ B)
+
+    _⇒A_ = ExpA._⇒_
+    _⇒B_ = ExpB._⇒_
+
+    CLAᴰ = isFibrationSETᴰ {c = B}{c' = A} Aᴰ f
+    CLAᴰ' = isFibrationSETᴰ {c = B}{c' = A} Aᴰ' f
+    CLAᴰ⇒Aᴰ' = isFibrationSETᴰ {c = B}{c' = A} (Aᴰ ⇒A Aᴰ') f
+    module f*Aᴰ = CartesianLift CLAᴰ
+    module f*Aᴰ' = CartesianLift CLAᴰ'
+    module f*Aᴰ⇒Aᴰ' = CartesianLift CLAᴰ⇒Aᴰ'
+
+    expPshA : Functor (SETᴰ.v[ A ] ^op) (SET (ℓ-max ℓ ℓ'))
+    expPshA = ExponentiableProf SETᴰ.v[ A ] (bpw Aᴰ) .F-ob Aᴰ'
+
+    expPshB : Functor (SETᴰ.v[ B ] ^op) (SET (ℓ-max ℓ ℓ'))
+    expPshB = ExponentiableProf SETᴰ.v[ B ] (bpw (f* Aᴰ)) .F-ob (f* Aᴰ')
+
+    module PA = PresheafNotation expPshA
+    module PB = PresheafNotation expPshB
+
+    --              λgᴰ
+    --    Bᴰ -------------> f* (Aᴰ ⇒A Aᴰ')
+    --    |                       |
+    --    |                       |
+    --    |                       |
+    --    v                       v
+    --    B --------------------> B
+    --             id
+    λgᴰ : SETᴰ.v[ B ] [ Bᴰ , (f* Aᴰ) ⇒B (f* Aᴰ') ]
+    λgᴰ = ExpB.lda gᴰ
+
+    pshHom : PshHomᴰ f*F expPshA expPshB
+    pshHom = preservesExpCone f*F (bpw Aᴰ)
+      (λ Aᴰ' → cartesianLift-preserves-BinProductFiber (SETᴰ ℓ ℓ') isFibrationSETᴰ
+                       (BinProductsⱽSETᴰ A (Aᴰ' , Aᴰ)) f)
+      (bpw (f* Aᴰ)) Aᴰ'
+    α : (Aᴰ'' : ob SETᴰ.v[ A ]) → PA.p[ Aᴰ'' ] → PB.p[ f* Aᴰ'' ]
+    α = pshHom .fst
+
+    vert≡ : ∀ {Aᴰ Aᴰ'} → (f* (Aᴰ ⇒A Aᴰ')) ≡ ((f* Aᴰ) ⇒B (f* Aᴰ'))
+    vert≡ = refl
+
+    app≡ : α (Aᴰ ⇒A Aᴰ') ExpA.app ≡ ExpB.app
+    app≡ = β (FiberExponentialSETᴰ B (f* Aᴰ) (f* Aᴰ'))

--- a/Cubical/Categories/Displayed/Instances/Sets/Properties.agda
+++ b/Cubical/Categories/Displayed/Instances/Sets/Properties.agda
@@ -102,7 +102,6 @@ SETᴰCartesianCategoryⱽ ℓ ℓ' .CartesianCategoryⱽ.termⱽ = Terminalsⱽ
 SETᴰCartesianCategoryⱽ ℓ ℓ' .CartesianCategoryⱽ.bpⱽ = BinProductsⱽSETᴰ
 SETᴰCartesianCategoryⱽ ℓ ℓ' .CartesianCategoryⱽ.cartesianLifts = isFibrationSETᴰ
 
-
 module _ {ℓ} {ℓ'} where
   private
     module SETᴰ = Fibers (SETᴰ ℓ ℓ')

--- a/Cubical/Categories/Exponentials.agda
+++ b/Cubical/Categories/Exponentials.agda
@@ -94,9 +94,6 @@ module ExponentialNotation {C : Category ℓC ℓC'}{c d} -×c (exp : Exponentia
   lda : ∀ {Γ} → C [ Γ ×a , d ] → C [ Γ , vert ]
   lda = intro
 
-  β⇒ : ∀ {Γ} → (f : C [ Γ ×a , d ]) → ((π₁ C.⋆ lda f) ,p π₂) C.⋆ app ≡ f
-  β⇒ f = β
-
 module ExponentiableNotation {C : Category ℓC ℓC'}{c}
   -×c
   (c⇒- : Exponentiable C c -×c) where

--- a/Cubical/Categories/Exponentials.agda
+++ b/Cubical/Categories/Exponentials.agda
@@ -94,6 +94,9 @@ module ExponentialNotation {C : Category ℓC ℓC'}{c d} -×c (exp : Exponentia
   lda : ∀ {Γ} → C [ Γ ×a , d ] → C [ Γ , vert ]
   lda = intro
 
+  β⇒ : ∀ {Γ} → (f : C [ Γ ×a , d ]) → ((π₁ C.⋆ lda f) ,p π₂) C.⋆ app ≡ f
+  β⇒ f = β
+
 module ExponentiableNotation {C : Category ℓC ℓC'}{c}
   -×c
   (c⇒- : Exponentiable C c -×c) where


### PR DESCRIPTION
To do the equational proofs, it took me two days of unpacking equivalent definitions to realize how simple this actually is

The code can be cleaned up and compacted, but I'm gonna submit this PR and go home bc I've been staring at my monitor for far too long

It seems that a lot of things are definitionally nice in displayed sets. It's been a while since using them that I'd forgotten that `f` composed with identity is definitionally `f`, same with associativity. I was also surprised that the cartesian lift definitionally preserves the vertex of an exponential in each fiber category
```
    vert≡ : ∀ {Aᴰ Aᴰ'} → (f* (Aᴰ ⇒A Aᴰ')) ≡ ((f* Aᴰ) ⇒B (f* Aᴰ'))
    vert≡ = refl
```

In an arbitrary category, I'd expect exponential objects should only be preserved up to iso, is this correct? (I'm trying to understand how much harder the presheaf example might be than this)